### PR TITLE
Move LDFLAGS in Makefile to fix Linux build

### DIFF
--- a/kafka/Makefile
+++ b/kafka/Makefile
@@ -25,7 +25,7 @@ OBJECTS=$(SOURCES:.c=.o)
 all: $(SOURCES) $(EXECUTABLE)
 
 $(EXECUTABLE): $(OBJECTS)
-	$(CC) $(LDFLAGS) $^ $(STATICLIB) -o $@
+	$(CC) $^ $(STATICLIB) -o $@ $(LDFLAGS)
 
 .c.o:
 	$(CC) $< $(CFLAGS) -o $@


### PR DESCRIPTION
I was trying to build the project in Ubuntu 14.04 x64 (gcc 4.8.2, `3.16.0-34-generic` kernel) and kept getting linking errors.

This got the build to succeed without error. (I haven't had a chance to actually test BW yet :D)

Can you test this and see if it breaks anything?

This is my first open source pull request (I've opened many in private repos for work), so apologies if I've done anything wrong with this. Thanks!