### PR TITLE
Decouple logical decoding and AVRO format.

### DIFF
--- a/ext/Makefile
+++ b/ext/Makefile
@@ -7,7 +7,7 @@ AVRO_LDFLAGS = $(shell pkg-config --libs avro-c)
 PG_CPPFLAGS += $(AVRO_CFLAGS) -std=c99
 SHLIB_LINK += $(AVRO_LDFLAGS)
 
-OBJS = io_util.o logdecoder.o oid2avro.o protocol.o protocol_server.o snapshot.o
+OBJS = io_util.o logdecoder.o format-avro.o oid2avro.o protocol.o protocol_server.o snapshot.o
 DATA = bottledwater--0.1.sql
 
 PG_CONFIG = pg_config

--- a/ext/Makefile
+++ b/ext/Makefile
@@ -7,7 +7,7 @@ AVRO_LDFLAGS = $(shell pkg-config --libs avro-c)
 PG_CPPFLAGS += $(AVRO_CFLAGS) -std=c99
 SHLIB_LINK += $(AVRO_LDFLAGS)
 
-OBJS = io_util.o logdecoder.o format-avro.o oid2avro.o protocol.o protocol_server.o snapshot.o
+OBJS = io_util.o logdecoder.o format-avro.o format-json.o oid2avro.o protocol.o protocol_server.o snapshot.o
 DATA = bottledwater--0.1.sql
 
 PG_CONFIG = pg_config

--- a/ext/format-avro.c
+++ b/ext/format-avro.c
@@ -1,0 +1,144 @@
+#include "logdecoder.h"
+#include "format-avro.h"
+#include "io_util.h"
+#include "protocol_server.h"
+#include "oid2avro.h"
+
+static void output_avro_startup(LogicalDecodingContext *ctx, OutputPluginOptions *opt, bool is_init);
+static void output_avro_shutdown(LogicalDecodingContext *ctx);
+static void output_avro_begin_txn(LogicalDecodingContext *ctx, ReorderBufferTXN *txn);
+static void output_avro_commit_txn(LogicalDecodingContext *ctx, ReorderBufferTXN *txn, XLogRecPtr commit_lsn);
+static void output_avro_change(LogicalDecodingContext *ctx, ReorderBufferTXN *txn, Relation rel, ReorderBufferChange *change);
+
+typedef struct {
+    avro_schema_t frame_schema;
+    avro_value_iface_t *frame_iface;
+    avro_value_t frame_value;
+    schema_cache_t schema_cache;
+} plugin_state_avro;
+
+void reset_frame(plugin_state_avro *state);
+int write_frame(LogicalDecodingContext *ctx, plugin_state_avro *state);
+
+
+void output_format_avro_init(OutputPluginCallbacks *cb) {
+    elog(DEBUG1, "bottledwater: output_format_avro_init");
+    cb->startup_cb = output_avro_startup;
+    cb->begin_cb = output_avro_begin_txn;
+    cb->change_cb = output_avro_change;
+    cb->commit_cb = output_avro_commit_txn;
+    cb->shutdown_cb = output_avro_shutdown;
+}
+
+static void output_avro_startup(LogicalDecodingContext *ctx, OutputPluginOptions *opt,
+        bool is_init) {
+    plugin_state_avro *state = palloc(sizeof(plugin_state_avro));
+    private_state(ctx) = state;
+    opt->output_type = OUTPUT_PLUGIN_BINARY_OUTPUT;
+
+    state->frame_schema = schema_for_frame();
+    state->frame_iface = avro_generic_class_from_schema(state->frame_schema);
+    avro_generic_value_new(state->frame_iface, &state->frame_value);
+    state->schema_cache = schema_cache_new(ctx->context);
+}
+
+static void output_avro_shutdown(LogicalDecodingContext *ctx) {
+    plugin_state_avro *state = private_state(ctx);
+
+    schema_cache_free(state->schema_cache);
+    avro_value_decref(&state->frame_value);
+    avro_value_iface_decref(state->frame_iface);
+    avro_schema_decref(state->frame_schema);
+}
+
+static void output_avro_begin_txn(LogicalDecodingContext *ctx, ReorderBufferTXN *txn) {
+    plugin_state_avro *state = private_state(ctx);
+    reset_frame(state);
+
+    if (update_frame_with_begin_txn(&state->frame_value, txn)) {
+        elog(ERROR, "output_avro_begin_txn: Avro conversion failed: %s", avro_strerror());
+    }
+    if (write_frame(ctx, state)) {
+        elog(ERROR, "output_avro_begin_txn: writing Avro binary failed: %s", avro_strerror());
+    }
+}
+
+static void output_avro_commit_txn(LogicalDecodingContext *ctx, ReorderBufferTXN *txn,
+        XLogRecPtr commit_lsn) {
+    plugin_state_avro *state = private_state(ctx);
+    reset_frame(state);
+
+    if (update_frame_with_commit_txn(&state->frame_value, txn, commit_lsn)) {
+        elog(ERROR, "output_avro_commit_txn: Avro conversion failed: %s", avro_strerror());
+    }
+    if (write_frame(ctx, state)) {
+        elog(ERROR, "output_avro_commit_txn: writing Avro binary failed: %s", avro_strerror());
+    }
+}
+
+static void output_avro_change(LogicalDecodingContext *ctx, ReorderBufferTXN *txn,
+        Relation rel, ReorderBufferChange *change) {
+    int err = 0;
+    HeapTuple oldtuple = NULL, newtuple = NULL;
+    plugin_state_avro *state = private_state(ctx);
+    reset_frame(state);
+
+    switch (change->action) {
+        case REORDER_BUFFER_CHANGE_INSERT:
+            if (!change->data.tp.newtuple) {
+                elog(ERROR, "output_avro_change: insert action without a tuple");
+            }
+            newtuple = &change->data.tp.newtuple->tuple;
+            err = update_frame_with_insert(&state->frame_value, state->schema_cache, rel,
+                    RelationGetDescr(rel), newtuple);
+            break;
+
+        case REORDER_BUFFER_CHANGE_UPDATE:
+            if (!change->data.tp.newtuple) {
+                elog(ERROR, "output_avro_change: update action without a tuple");
+            }
+            if (change->data.tp.oldtuple) {
+                oldtuple = &change->data.tp.oldtuple->tuple;
+            }
+            newtuple = &change->data.tp.newtuple->tuple;
+            err = update_frame_with_update(&state->frame_value, state->schema_cache, rel, oldtuple, newtuple);
+            break;
+
+        case REORDER_BUFFER_CHANGE_DELETE:
+            if (change->data.tp.oldtuple) {
+                oldtuple = &change->data.tp.oldtuple->tuple;
+            }
+            err = update_frame_with_delete(&state->frame_value, state->schema_cache, rel, oldtuple);
+            break;
+
+        default:
+            elog(ERROR, "output_avro_change: unknown change action %d", change->action);
+    }
+
+    if (err) {
+        elog(ERROR, "output_avro_change: row conversion failed: %s", avro_strerror());
+    }
+    if (write_frame(ctx, state)) {
+        elog(ERROR, "output_avro_change: writing Avro binary failed: %s", avro_strerror());
+    }
+}
+
+void reset_frame(plugin_state_avro *state) {
+    if (avro_value_reset(&state->frame_value)) {
+        elog(ERROR, "Avro value reset failed: %s", avro_strerror());
+    }
+}
+
+int write_frame(LogicalDecodingContext *ctx, plugin_state_avro *state) {
+    int err = 0;
+    bytea *output = NULL;
+
+    check(err, try_writing(&output, &write_avro_binary, &state->frame_value));
+
+    OutputPluginPrepareWrite(ctx, true);
+    appendBinaryStringInfo(ctx->out, VARDATA(output), VARSIZE(output) - VARHDRSZ);
+    OutputPluginWrite(ctx, true);
+
+    pfree(output);
+    return err;
+}

--- a/ext/format-avro.h
+++ b/ext/format-avro.h
@@ -1,0 +1,8 @@
+#ifndef FORMAT_AVRO_H
+#define FORMAT_AVRO_H
+
+#include "replication/output_plugin.h"
+
+void output_format_avro_init(OutputPluginCallbacks *cb);
+
+#endif /* FORMAT_AVRO_H */

--- a/ext/format-json.c
+++ b/ext/format-json.c
@@ -1,0 +1,124 @@
+#include "logdecoder.h"
+#include "format-json.h"
+#include "funcapi.h"
+#include "access/htup_details.h"
+#include "utils/json.h"
+#include "utils/lsyscache.h"
+
+#include "io_util.h"
+#include "protocol_server.h"
+
+static void output_json_startup(LogicalDecodingContext *ctx, OutputPluginOptions *opt, bool is_init);
+static void output_json_shutdown(LogicalDecodingContext *ctx);
+static void output_json_begin_txn(LogicalDecodingContext *ctx, ReorderBufferTXN *txn);
+static void output_json_commit_txn(LogicalDecodingContext *ctx, ReorderBufferTXN *txn, XLogRecPtr commit_lsn);
+static void output_json_change(LogicalDecodingContext *ctx, ReorderBufferTXN *txn, Relation rel, ReorderBufferChange *change);
+
+
+void output_format_json_init(OutputPluginCallbacks *cb) {
+    elog(DEBUG1, "bottledwater: output_format_json_init");
+    cb->startup_cb = output_json_startup;
+    cb->begin_cb = output_json_begin_txn;
+    cb->change_cb = output_json_change;
+    cb->commit_cb = output_json_commit_txn;
+    cb->shutdown_cb = output_json_shutdown;
+}
+
+static void output_json_startup(LogicalDecodingContext *ctx, OutputPluginOptions *opt,
+        bool is_init) {
+    opt->output_type = OUTPUT_PLUGIN_TEXTUAL_OUTPUT;
+}
+
+static void output_json_shutdown(LogicalDecodingContext *ctx) {
+}
+
+static void output_json_begin_txn(LogicalDecodingContext *ctx, ReorderBufferTXN *txn) {
+    OutputPluginPrepareWrite(ctx, true);
+    appendStringInfo(ctx->out, "{ \"command\": \"BEGIN\", \"xid\": %u }", txn->xid);
+    OutputPluginWrite(ctx, true);
+}
+
+static void output_json_commit_txn(LogicalDecodingContext *ctx, ReorderBufferTXN *txn,
+        XLogRecPtr commit_lsn) {
+    OutputPluginPrepareWrite(ctx, true);
+    appendStringInfo(ctx->out, "{ \"command\": \"COMMIT\", \"xid\": %u }", txn->xid);
+    OutputPluginWrite(ctx, true);
+}
+
+static void output_json_change(LogicalDecodingContext *ctx, ReorderBufferTXN *txn,
+        Relation rel, ReorderBufferChange *change) {
+    HeapTuple oldtuple = NULL, newtuple = NULL;
+    Datum olddatum = NULL, newdatum = NULL, oldjson = NULL, newjson = NULL;
+    text *oldtext = NULL, *newtext = NULL;
+    const char *command = NULL;
+
+    switch (change->action) {
+        case REORDER_BUFFER_CHANGE_INSERT:
+            if (!change->data.tp.newtuple) {
+                elog(ERROR, "output_json_change: insert action without a tuple");
+            }
+            newtuple = &change->data.tp.newtuple->tuple;
+
+            command = "INSERT";
+            break;
+
+        case REORDER_BUFFER_CHANGE_UPDATE:
+            if (!change->data.tp.newtuple) {
+                elog(ERROR, "output_json_change: update action without a tuple");
+            }
+            newtuple = &change->data.tp.newtuple->tuple;
+
+            if (change->data.tp.oldtuple) {
+                oldtuple = &change->data.tp.oldtuple->tuple;
+            }
+            command = "UPDATE";
+            break;
+
+        case REORDER_BUFFER_CHANGE_DELETE:
+            if (change->data.tp.oldtuple) {
+                oldtuple = &change->data.tp.oldtuple->tuple;
+            }
+            command = "DELETE";
+            break;
+
+        default:
+            elog(ERROR, "output_json_change: unknown change action %d", change->action);
+    }
+
+    if (newtuple) {
+        newdatum = heap_copy_tuple_as_datum(newtuple, RelationGetDescr(rel));
+        newjson = DirectFunctionCall1(row_to_json, newdatum);
+        newtext = DatumGetTextP(newjson);
+    }
+    if (oldtuple) {
+        olddatum = heap_copy_tuple_as_datum(oldtuple, RelationGetDescr(rel));
+        oldjson = DirectFunctionCall1(row_to_json, olddatum);
+        oldtext = DatumGetTextP(oldjson);
+    }
+
+    OutputPluginPrepareWrite(ctx, true);
+    appendStringInfo(ctx->out, "{ \"xid\": %u, \"wal_pos\": \"%X/%X\"",
+                     txn->xid, (uint32) (change->lsn >> 32), (uint32) change->lsn);
+    appendStringInfo(ctx->out, ", \"command\": \"%s\"", command);
+    appendStringInfo(ctx->out, ", \"relname\": \"%s\"", RelationGetRelationName(rel));
+    appendStringInfo(ctx->out, ", \"relnamespace\": \"%s\"", get_namespace_name(RelationGetNamespace(rel)));
+    if (newtuple) {
+        appendStringInfoString(ctx->out, ", \"newtuple\": ");
+        appendBinaryStringInfo(ctx->out, VARDATA_ANY(newtext), VARSIZE_ANY_EXHDR(newtext));
+    }
+    if (oldtuple) {
+        appendStringInfoString(ctx->out, ", \"oldtuple\": ");
+        appendBinaryStringInfo(ctx->out, VARDATA_ANY(oldtext), VARSIZE_ANY_EXHDR(oldtext));
+    }
+    appendStringInfoString(ctx->out, " }");
+    OutputPluginWrite(ctx, true);
+
+    if (oldtuple) {
+        pfree(DatumGetPointer(oldjson));
+        pfree(DatumGetPointer(olddatum));
+    }
+    if (newtuple) {
+        pfree(DatumGetPointer(newjson));
+        pfree(DatumGetPointer(newdatum));
+    }
+}

--- a/ext/format-json.c
+++ b/ext/format-json.c
@@ -112,13 +112,4 @@ static void output_json_change(LogicalDecodingContext *ctx, ReorderBufferTXN *tx
     }
     appendStringInfoString(ctx->out, " }");
     OutputPluginWrite(ctx, true);
-
-    if (oldtuple) {
-        pfree(DatumGetPointer(oldjson));
-        pfree(DatumGetPointer(olddatum));
-    }
-    if (newtuple) {
-        pfree(DatumGetPointer(newjson));
-        pfree(DatumGetPointer(newdatum));
-    }
 }

--- a/ext/format-json.h
+++ b/ext/format-json.h
@@ -1,0 +1,8 @@
+#ifndef FORMAT_JSON_H
+#define FORMAT_JSON_H
+
+#include "replication/output_plugin.h"
+
+void output_format_json_init(OutputPluginCallbacks *cb);
+
+#endif /* FORMAT_JSON_H */

--- a/ext/logdecoder.c
+++ b/ext/logdecoder.c
@@ -1,170 +1,122 @@
-#include "io_util.h"
-#include "protocol_server.h"
-#include "oid2avro.h"
-
-#include "replication/logical.h"
-#include "replication/output_plugin.h"
-#include "utils/memutils.h"
+#include "logdecoder.h"
+#include "format-avro.h"
+#include "nodes/parsenodes.h"
+#include "utils/elog.h"
 
 /* Entry point when Postgres loads the plugin */
 extern void _PG_init(void);
 extern void _PG_output_plugin_init(OutputPluginCallbacks *cb);
 
-static void output_avro_startup(LogicalDecodingContext *ctx, OutputPluginOptions *opt, bool is_init);
-static void output_avro_shutdown(LogicalDecodingContext *ctx);
-static void output_avro_begin_txn(LogicalDecodingContext *ctx, ReorderBufferTXN *txn);
-static void output_avro_commit_txn(LogicalDecodingContext *ctx, ReorderBufferTXN *txn, XLogRecPtr commit_lsn);
-static void output_avro_change(LogicalDecodingContext *ctx, ReorderBufferTXN *txn, Relation rel, ReorderBufferChange *change);
-
-typedef struct {
-    MemoryContext memctx; /* reset after every change event, to prevent leaks */
-    avro_schema_t frame_schema;
-    avro_value_iface_t *frame_iface;
-    avro_value_t frame_value;
-    schema_cache_t schema_cache;
-} plugin_state;
-
-void reset_frame(plugin_state *state);
-int write_frame(LogicalDecodingContext *ctx, plugin_state *state);
+static void output_startup(LogicalDecodingContext *ctx, OutputPluginOptions *opt, bool is_init);
+static void output_shutdown(LogicalDecodingContext *ctx);
+static void output_begin_txn(LogicalDecodingContext *ctx, ReorderBufferTXN *txn);
+static void output_commit_txn(LogicalDecodingContext *ctx, ReorderBufferTXN *txn, XLogRecPtr commit_lsn);
+static void output_change(LogicalDecodingContext *ctx, ReorderBufferTXN *txn, Relation rel, ReorderBufferChange *change);
 
 
 void _PG_init() {
 }
 
 void _PG_output_plugin_init(OutputPluginCallbacks *cb) {
+    elog(DEBUG1, "bottledwater: _PG_output_plugin_init");
     AssertVariableIsOfType(&_PG_output_plugin_init, LogicalOutputPluginInit);
-    cb->startup_cb = output_avro_startup;
-    cb->begin_cb = output_avro_begin_txn;
-    cb->change_cb = output_avro_change;
-    cb->commit_cb = output_avro_commit_txn;
-    cb->shutdown_cb = output_avro_shutdown;
+    cb->startup_cb = output_startup;
+    cb->begin_cb = output_begin_txn;
+    cb->change_cb = output_change;
+    cb->commit_cb = output_commit_txn;
+    cb->shutdown_cb = output_shutdown;
 }
 
-static void output_avro_startup(LogicalDecodingContext *ctx, OutputPluginOptions *opt,
+static void output_startup(LogicalDecodingContext *ctx, OutputPluginOptions *opt,
         bool is_init) {
-    plugin_state *state = palloc(sizeof(plugin_state));
-    ctx->output_plugin_private = state;
-    opt->output_type = OUTPUT_PLUGIN_BINARY_OUTPUT;
+    plugin_state *state;
 
-    state->memctx = AllocSetContextCreate(ctx->context, "Avro decoder context",
+    elog(DEBUG1, "bottledwater: output_startup: is_init=%s", is_init ? "true" : "false");
+
+    state = palloc0(sizeof(plugin_state));
+    ctx->output_plugin_private = state;
+
+    state->memctx = AllocSetContextCreate(ctx->context, "Bottledwater decoder context",
             ALLOCSET_DEFAULT_MINSIZE, ALLOCSET_DEFAULT_INITSIZE, ALLOCSET_DEFAULT_MAXSIZE);
 
-    state->frame_schema = schema_for_frame();
-    state->frame_iface = avro_generic_class_from_schema(state->frame_schema);
-    avro_generic_value_new(state->frame_iface, &state->frame_value);
-    state->schema_cache = schema_cache_new(ctx->context);
+    if (ctx->output_plugin_options) {
+        ListCell *o;
+
+        foreach(o, ctx->output_plugin_options) {
+          DefElem *e;
+
+          e = (DefElem *) lfirst(o);
+          if (strcasecmp(e->defname, "FORMAT") == 0) {
+              char *str;
+
+              if (e->arg) {
+                str = ((Value *) e->arg)->val.str;
+              } else {
+                  ereport(ERROR,
+                          (errcode(ERRCODE_UNDEFINED_PARAMETER),
+                           errmsg("FORMAT option requires an argument")));
+              }
+              if (state->format_cb) {
+                  ereport(ERROR,
+                          (errcode(ERRCODE_AMBIGUOUS_PARAMETER), // TODO: a better one?
+                           errmsg("multiple FORMAT options specified for output plugin")));
+              }
+              if (strcasecmp(str, "AVRO") == 0) {
+                  ; // default format, see below
+              } else {
+                  ereport(ERROR,
+                          (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+                           errmsg("unsupported FORMAT option: %s", str)));
+              }
+          }
+        }
+    }
+
+    // use default format, if not created earlier
+    if (!state->format_cb) {
+      state->format_cb = palloc0(sizeof(OutputPluginCallbacks));
+      output_format_avro_init(state->format_cb);
+    }
+
+    state->format_cb->startup_cb(ctx, opt, is_init);
 }
 
-static void output_avro_shutdown(LogicalDecodingContext *ctx) {
+static void output_shutdown(LogicalDecodingContext *ctx) {
     plugin_state *state = ctx->output_plugin_private;
-    MemoryContextDelete(state->memctx);
 
-    schema_cache_free(state->schema_cache);
-    avro_value_decref(&state->frame_value);
-    avro_value_iface_decref(state->frame_iface);
-    avro_schema_decref(state->frame_schema);
+    state->format_cb->shutdown_cb(ctx);
+
+    MemoryContextDelete(state->memctx);
 }
 
-static void output_avro_begin_txn(LogicalDecodingContext *ctx, ReorderBufferTXN *txn) {
+static void output_begin_txn(LogicalDecodingContext *ctx, ReorderBufferTXN *txn) {
     plugin_state *state = ctx->output_plugin_private;
     MemoryContext oldctx = MemoryContextSwitchTo(state->memctx);
-    reset_frame(state);
 
-    if (update_frame_with_begin_txn(&state->frame_value, txn)) {
-        elog(ERROR, "output_avro_begin_txn: Avro conversion failed: %s", avro_strerror());
-    }
-    if (write_frame(ctx, state)) {
-        elog(ERROR, "output_avro_begin_txn: writing Avro binary failed: %s", avro_strerror());
-    }
+    state->format_cb->begin_cb(ctx, txn);
 
     MemoryContextSwitchTo(oldctx);
     MemoryContextReset(state->memctx);
 }
 
-static void output_avro_commit_txn(LogicalDecodingContext *ctx, ReorderBufferTXN *txn,
+static void output_commit_txn(LogicalDecodingContext *ctx, ReorderBufferTXN *txn,
         XLogRecPtr commit_lsn) {
     plugin_state *state = ctx->output_plugin_private;
     MemoryContext oldctx = MemoryContextSwitchTo(state->memctx);
-    reset_frame(state);
 
-    if (update_frame_with_commit_txn(&state->frame_value, txn, commit_lsn)) {
-        elog(ERROR, "output_avro_commit_txn: Avro conversion failed: %s", avro_strerror());
-    }
-    if (write_frame(ctx, state)) {
-        elog(ERROR, "output_avro_commit_txn: writing Avro binary failed: %s", avro_strerror());
-    }
+    state->format_cb->commit_cb(ctx, txn, commit_lsn);
 
     MemoryContextSwitchTo(oldctx);
     MemoryContextReset(state->memctx);
 }
 
-static void output_avro_change(LogicalDecodingContext *ctx, ReorderBufferTXN *txn,
+static void output_change(LogicalDecodingContext *ctx, ReorderBufferTXN *txn,
         Relation rel, ReorderBufferChange *change) {
-    int err = 0;
-    HeapTuple oldtuple = NULL, newtuple = NULL;
     plugin_state *state = ctx->output_plugin_private;
     MemoryContext oldctx = MemoryContextSwitchTo(state->memctx);
-    reset_frame(state);
 
-    switch (change->action) {
-        case REORDER_BUFFER_CHANGE_INSERT:
-            if (!change->data.tp.newtuple) {
-                elog(ERROR, "output_avro_change: insert action without a tuple");
-            }
-            newtuple = &change->data.tp.newtuple->tuple;
-            err = update_frame_with_insert(&state->frame_value, state->schema_cache, rel,
-                    RelationGetDescr(rel), newtuple);
-            break;
-
-        case REORDER_BUFFER_CHANGE_UPDATE:
-            if (!change->data.tp.newtuple) {
-                elog(ERROR, "output_avro_change: update action without a tuple");
-            }
-            if (change->data.tp.oldtuple) {
-                oldtuple = &change->data.tp.oldtuple->tuple;
-            }
-            newtuple = &change->data.tp.newtuple->tuple;
-            err = update_frame_with_update(&state->frame_value, state->schema_cache, rel, oldtuple, newtuple);
-            break;
-
-        case REORDER_BUFFER_CHANGE_DELETE:
-            if (change->data.tp.oldtuple) {
-                oldtuple = &change->data.tp.oldtuple->tuple;
-            }
-            err = update_frame_with_delete(&state->frame_value, state->schema_cache, rel, oldtuple);
-            break;
-
-        default:
-            elog(ERROR, "output_avro_change: unknown change action %d", change->action);
-    }
-
-    if (err) {
-        elog(ERROR, "output_avro_change: row conversion failed: %s", avro_strerror());
-    }
-    if (write_frame(ctx, state)) {
-        elog(ERROR, "output_avro_change: writing Avro binary failed: %s", avro_strerror());
-    }
+    state->format_cb->change_cb(ctx, txn, rel, change);
 
     MemoryContextSwitchTo(oldctx);
     MemoryContextReset(state->memctx);
-}
-
-void reset_frame(plugin_state *state) {
-    if (avro_value_reset(&state->frame_value)) {
-        elog(ERROR, "Avro value reset failed: %s", avro_strerror());
-    }
-}
-
-int write_frame(LogicalDecodingContext *ctx, plugin_state *state) {
-    int err = 0;
-    bytea *output = NULL;
-
-    check(err, try_writing(&output, &write_avro_binary, &state->frame_value));
-
-    OutputPluginPrepareWrite(ctx, true);
-    appendBinaryStringInfo(ctx->out, VARDATA(output), VARSIZE(output) - VARHDRSZ);
-    OutputPluginWrite(ctx, true);
-
-    pfree(output);
-    return err;
 }

--- a/ext/logdecoder.c
+++ b/ext/logdecoder.c
@@ -32,7 +32,9 @@ static void output_startup(LogicalDecodingContext *ctx, OutputPluginOptions *opt
     plugin_state *state;
 
     elog(DEBUG1, "bottledwater: output_startup: is_init=%s", is_init ? "true" : "false");
-
+    if (is_init) {
+        return;
+    }
     state = palloc0(sizeof(plugin_state));
     ctx->output_plugin_private = state;
 

--- a/ext/logdecoder.h
+++ b/ext/logdecoder.h
@@ -1,0 +1,17 @@
+#ifndef LOGDECODER_H
+#define LOGDECODER_H
+
+#include "postgres.h"
+#include "replication/logical.h"
+#include "replication/output_plugin.h"
+#include "utils/memutils.h"
+
+typedef struct {
+    MemoryContext memctx; /* reset after every change event, to prevent leaks */
+    OutputPluginCallbacks *format_cb;
+    void *format_state;
+} plugin_state;
+
+#define private_state(ctx) (((plugin_state *) ctx->output_plugin_private)->format_state)
+
+#endif /* LOGDECODER_H */


### PR DESCRIPTION
Provides for different output formats that can be chosen by the
connecting client using plugin options in the start command:

  START_REPLICATION SLOT \<slot\> LOGICAL \<XXX/XXX\> (FORMAT '\<format\>')

If not specified, AVRO is used as the default output format.