### PR TITLE
Log debug info on row conversion failure

### DIFF
--- a/ext/logdecoder.c
+++ b/ext/logdecoder.c
@@ -139,6 +139,7 @@ static void output_avro_change(LogicalDecodingContext *ctx, ReorderBufferTXN *tx
     }
 
     if (err) {
+        elog(INFO, "Row conversion failed: %s", schema_debug_info(rel, NULL));
         elog(ERROR, "output_avro_change: row conversion failed: %s", avro_strerror());
     }
     if (write_frame(ctx, state)) {

--- a/ext/protocol_server.h
+++ b/ext/protocol_server.h
@@ -34,5 +34,6 @@ int update_frame_with_delete(avro_value_t *frame_val, schema_cache_t cache, Rela
 
 schema_cache_t schema_cache_new(MemoryContext context);
 void schema_cache_free(schema_cache_t cache);
+char *schema_debug_info(Relation rel, TupleDesc tupdesc);
 
 #endif /* PROTOCOL_SERVER_H */


### PR DESCRIPTION
If the conversion of Postgres tuple to Avro fails, log details of the tuple descriptor so that we can track down the problem.