### PR TITLE
Minor update dependencies documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ with contents something like the following:
     Name: libsnappy
     Description: Snappy is a compression library
     Version: 1.1.2
-    URL: https://code.google.com/p/snappy/
+    URL: https://google.github.io/snappy/
     Libs: -L/usr/local/lib -lsnappy
     Cflags: -I/usr/local/include
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,8 @@ as an example of building Bottled Water and its dependencies on Debian.
 
 If you get errors about *Package libsnappy was not found in the pkg-config search path*,
 and you have Snappy installed, you may need to create `/usr/local/lib/pkgconfig/libsnappy.pc`
-with contents something like the following:
+with contents something like the following (be sure to check which version of _libsnappy_
+is installed in your system):
 
     Name: libsnappy
     Description: Snappy is a compression library

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ For that to work, you need the following dependencies installed:
   (Homebrew: `brew install jansson`; Ubuntu: `sudo apt-get install libjansson-dev`)
 * [libcurl](http://curl.haxx.se/libcurl/), a HTTP client.
   (Homebrew: `brew install curl`; Ubuntu: `sudo apt-get install libcurl4-openssl-dev`)
-* [librdkafka](https://github.com/edenhill/librdkafka), a Kafka client.
+* [librdkafka](https://github.com/edenhill/librdkafka) (0.8.4 or later), a Kafka client.
   (Ubuntu universe: `sudo apt-get install librdkafka-dev`; others: build from source)
 
 You can see the Dockerfile for


### PR DESCRIPTION
Bottled Water depends on _librdkafka_ **0.8.4 or later** because it [refers](https://github.com/confluentinc/bottledwater-pg/blob/master/kafka/bottledwater.c#L492) to [`rd_kafka_conf_set_dr_msg_cb`](https://github.com/edenhill/librdkafka/blob/0.8.4/src/rdkafka.h#L307-L311), which was introduced in 0.8.4 ([source](https://github.com/edenhill/librdkafka/commit/acabf5ea9d7b241bc036e16c2e93c58d02e098f4)).

Besides, the [libsnappy](https://google.github.io/snappy) documentation is now hosted to Github : )