### PR TITLE
Update README to recommend librdkafka 0.8.6+

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ There are several possible ways of installing and trying Bottled Water:
   only recommended for development environments.
 * [Building from source](#building-from-source) is the most flexible, but also a bit fiddly.
 * There are also [Ubuntu packages](https://launchpad.net/~stub/+archive/ubuntu/bottledwater),
-  built by Stuart Bishop (Canonical), but see [notes about compaction](#note-about-ubuntu-packages-and-compaction).
+  built by Stuart Bishop (Canonical).
 
 
 Running in Docker
@@ -245,10 +245,6 @@ At time of writing, the librdkafka-dev packages in Ubuntu (for all releases up t
 15.10) contain a release prior to 0.8.6.  This means if you are building on Ubuntu,
 building librdkafka from source is recommended, until an updated librdkafka package
 is available.
-
-Building Bottled Water from source is currently recommended over the [Ubuntu
-bottledwater package](https://launchpad.net/~stub/+archive/ubuntu/bottledwater)
-since that package is built against librdkafka 0.8.5.
 
 
 Status

--- a/README.md
+++ b/README.md
@@ -241,10 +241,10 @@ sequence.  This means that Kafka will not garbage-collect deleted values on log
 compaction, and also may confuse consumers that expect all non-null message payloads
 to begin with a header.
 
-At time of writing, the librdkafka-dev packages in Ubuntu (for all releases up to
-15.10) contain a release prior to 0.8.6.  This means if you are building on Ubuntu,
-building librdkafka from source is recommended, until an updated librdkafka package
-is available.
+At time of writing, the librdkafka-dev packages in the official Ubuntu repositories
+(for all releases up to 15.10) contain a release prior to 0.8.6.  This means if you
+are building on Ubuntu, building librdkafka from source is recommended, until an
+updated librdkafka package is available.
 
 
 Status


### PR DESCRIPTION
Bottled Water relies on null message payloads for log compaction correctness; however librdkafka only added support for null messages in release 0.8.6.  This updates the readme to recommend 0.8.6+.  Since both the official Ubuntu librdkafka packages, and the PPA bottledwater package, predate 0.8.6, this also recommends against using those packages until they are updated.

Since the PPA includes a custom build of librdkafka, I'm sure it wouldn't be difficult to update the version of librdkafka it builds against, but I'm not sure of the best channel to propose that change?