### PR TITLE
Removing key_index from the cache entry struct.

### DIFF
--- a/ext/oid2avro.c
+++ b/ext/oid2avro.c
@@ -82,17 +82,15 @@ Relation table_key_index(Relation rel) {
 
 /* Generates an Avro schema for the key (replica identity or primary key)
  * of a given table. Returns null if the table is unkeyed. */
-avro_schema_t schema_for_table_key(Relation rel, Form_pg_index *index_out) {
+avro_schema_t schema_for_table_key(Relation rel) {
     Relation index_rel;
-        avro_schema_t schema;
+    avro_schema_t schema;
 
     index_rel = table_key_index(rel);
     if (!index_rel) return NULL;
 
     schema = schema_for_table_row(index_rel);
-    if (index_out) {
-        *index_out = index_rel->rd_index;
-    }
+
     relation_close(index_rel, AccessShareLock);
     return schema;
 }

--- a/ext/oid2avro.h
+++ b/ext/oid2avro.h
@@ -10,7 +10,7 @@
 #define PREDEFINED_SCHEMA_NAMESPACE "com.martinkl.bottledwater.datatypes"
 
 Relation table_key_index(Relation rel);
-avro_schema_t schema_for_table_key(Relation rel, Form_pg_index *index_out);
+avro_schema_t schema_for_table_key(Relation rel);
 avro_schema_t schema_for_table_row(Relation rel);
 int tuple_to_avro_row(avro_value_t *output_val, TupleDesc tupdesc, HeapTuple tuple);
 int tuple_to_avro_key(avro_value_t *output_val, TupleDesc tupdesc, HeapTuple tuple,

--- a/ext/protocol_server.h
+++ b/ext/protocol_server.h
@@ -14,7 +14,6 @@ typedef struct {
     avro_value_iface_t *row_iface;  /* Avro generic interface for creating row values */
     avro_value_t        key_value;  /* Avro key value, for encoding one key */
     avro_value_t        row_value;  /* Avro row value, for encoding one row */
-    Form_pg_index       key_index;  /* Postgres struct describing primary key/replident index */
 } schema_cache_entry;
 
 typedef struct {

--- a/ext/snapshot.c
+++ b/ext/snapshot.c
@@ -351,7 +351,7 @@ bytea *schema_for_relname(char *relname, bool get_key) {
     Relation rel = relation_openrv(relvar, AccessShareLock);
 
     if (get_key) {
-        schema = schema_for_table_key(rel, NULL);
+        schema = schema_for_table_key(rel);
     } else {
         schema = schema_for_table_row(rel);
     }


### PR DESCRIPTION
Fixing confluentinc/bottledwater-pg#32. 

I believe the problem lies in the `key_index ` field (of type `Form_pg_index`) of the  `schema_cache_entry` struct. After a while the `key_index` value of the cached entry is no longer available at the given memory location so when we try to use values of its fields in `tuple_to_avro_key`, those are just rubbish.

I don't know what the lifecycle of `Form_pg_index key_index` is, and how it is managed by postgres but my guess is that it may be updated by postgres and then the Relation simply points to a new value/memory location (unless the problem is around the relation locks).

Fetching the index by going again through the Relation fixes the problem.

Also, if anyone could point me to some good guide and/or documentation on the postgres C API I'd be very grateful!
