### PR TITLE
Partition updates consistently by key

### DIFF
--- a/kafka/bottledwater.c
+++ b/kafka/bottledwater.c
@@ -488,6 +488,13 @@ producer_context_t init_producer(client_context_t client) {
     context->topic_conf = rd_kafka_topic_conf_new();
     // xact_head, xact_tail and xact_list are set to zero by memset() above
 
+#if RD_KAFKA_VERSION >= 0x00090000
+    // librdkafka 0.9.0 includes an implementation of a "consistent hashing
+    // partitioner", which we can use to ensure that all updates for a given
+    // key go to the same partition.
+    rd_kafka_topic_conf_set_partitioner_cb(context->topic_conf, &rd_kafka_msg_partitioner_consistent);
+#endif
+
     set_topic_config(context, "produce.offset.report", "true");
     rd_kafka_conf_set_dr_msg_cb(context->kafka_conf, on_deliver_msg);
     return context;


### PR DESCRIPTION
Bottled Water produces messages using the "unassigned partition" (RD_KAFKA_PARTITION_UA), which "is used by the producer API for messages that should be partitioned using the configured or default partitioner".  The default partitioner is random.  This will lead to incorrect log compaction behaviour: e.g. if the initial insert for row 42 goes to partition 0, then a subsequent delete for row 42 goes to partition 1, then log compaction will be unable to garbage-collect the insert. It will also break any consumer relying on seeing all updates relating to a given key (e.g. for a stream-table join).

This patch configures BW's producer to instead use the "consistent partitioner" [added](https://github.com/edenhill/librdkafka/commit/0894e8f7d361fbf168809bdabbd06ad4b4a4fac8) in librdkafka v0.9.0, which partitions by the CRC32 of the key bytes.  This should ensure updates for the same key always go to the same partition, while doing a reasonably good job of load balancing between partitions.  If compiled against an older version of librdkafka it silently falls back (at compile time) to the default partitioner.

Hot keys could of course be a problem, but I don't think there's a general solution for that while providing the correct semantics.  A future direction might be to allow plugging in custom partitioners (e.g. via .so files).  In any case, if hot keys are a problem for the Kafka broker and/or consumers, they're probably also a problem for the source Postgres database in the first place!

Given that random partitioning creates some surprising and undesirable semantics for topics with more than one partition, this patch also makes 0.9.0 the recommended minimum version in the README.  If this PR is accepted we should also ask the maintainer of the Ubuntu PPA to update their librdkafka packages to 0.9.0.

There is a slight wrinkle in that although v0.9.0 of librdkafka [has been tagged](https://github.com/edenhill/librdkafka/releases/tag/v0.9.0), it doesn't appear to have been declared an official release yet.  In my testing BW behaves correctly (and this patch adds the desired behaviour) when compiled against the v0.9.0 tarball.

This branch is based off f5e5d83 rather than the latest master, because my testing shows a crash bug (#37) on master.  However, it should merge cleanly, since all subsequent changes in master are to unrelated areas of functionality.  I'm happy to rebase it onto master if that's preferred.