### PR TITLE
--output-format=json

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,12 +221,31 @@ complain and refuse to start. You can override this with the `--allow-unkeyed` o
 Any inserts and updates to tables without primary key or replica identity will be
 sent to Kafka as messages without a key. Deletes to such tables are not sent to Kafka.
 
-Messages are written to Kafka in a binary Avro encoding, which is efficient, but not
-human-readable. To view the contents of a Kafka topic, you can use the Avro console
-consumer:
+Messages are written to Kafka by default in a binary Avro encoding, which is
+efficient, but not human-readable. To view the contents of a Kafka topic, you can use
+the Avro console consumer:
 
     ./bin/kafka-avro-console-consumer --topic test --zookeeper localhost:2181 \
         --property print.key=true
+
+
+### Output formats
+
+Bottled Water currently supports writing messages to Kafka in one of two output
+formats: Avro, or JSON.  The output format is configured via the `--output-format`
+command-line switch.
+
+Avro is recommended for large scale use, since it uses a much more efficient binary
+encoding for messages, defines rules for [schema
+evolution](http://docs.confluent.io/1.0/avro.html), and is able to faithfully
+represent a wide range of column types.  Avro output requires an instance of the
+[Confluent Schema
+Registry](http://docs.confluent.io/1.0/schema-registry/docs/intro.html) to be running,
+and consumers will need to query the schema registry in order to decode messages.
+
+JSON is ideal for evaluation and prototyping, or integration with languages
+without good Avro library support.  JSON is human readable, and widely supported among
+programming languages.  JSON output does not require a schema registry.
 
 
 Known gotchas with older librdkafka versions

--- a/build/Dockerfile.client
+++ b/build/Dockerfile.client
@@ -19,7 +19,7 @@ ADD bottledwater-bin.tar.gz /
 RUN cp /usr/local/lib/librdkafka.so.1 /usr/lib/x86_64-linux-gnu && \
     cp /usr/local/lib/libavro.so.22.0.0 /usr/lib/x86_64-linux-gnu
 
-CMD /usr/local/bin/bottledwater \
+CMD /usr/local/bin/bottledwater --output-format avro \
+    --schema-registry http://${SCHEMA_REGISTRY_PORT_8081_TCP_ADDR}:${SCHEMA_REGISTRY_PORT_8081_TCP_PORT} \
     --postgres "hostaddr=${POSTGRES_PORT_5432_TCP_ADDR} port=${POSTGRES_PORT_5432_TCP_PORT} dbname=postgres user=postgres" \
-    --broker ${KAFKA_PORT_9092_TCP_ADDR}:${KAFKA_PORT_9092_TCP_PORT} \
-    --schema-registry http://${SCHEMA_REGISTRY_PORT_8081_TCP_ADDR}:${SCHEMA_REGISTRY_PORT_8081_TCP_PORT}
+    --broker ${KAFKA_PORT_9092_TCP_ADDR}:${KAFKA_PORT_9092_TCP_PORT}

--- a/kafka/Makefile
+++ b/kafka/Makefile
@@ -1,4 +1,4 @@
-SOURCES=bottledwater.c json.c registry.c
+SOURCES=bottledwater.c json.c registry.c table_mapper.c
 EXECUTABLE=bottledwater
 STATICLIB=../client/libbottledwater.a
 

--- a/kafka/Makefile
+++ b/kafka/Makefile
@@ -1,4 +1,4 @@
-SOURCES=bottledwater.c registry.c
+SOURCES=bottledwater.c json.c registry.c
 EXECUTABLE=bottledwater
 STATICLIB=../client/libbottledwater.a
 

--- a/kafka/bottledwater.c
+++ b/kafka/bottledwater.c
@@ -122,6 +122,8 @@ void usage() {
             "                          Comma-separated list of Kafka broker hosts/ports.\n"
             "  -r, --schema-registry=http://hostname:port   (default: %s)\n"
             "                          URL of the service where Avro schemas are registered.\n"
+            "                          Used only for --output-format=avro.\n"
+            "                          Omit when --output-format=json.\n"
             "  -f, --output-format=[avro|json]   (default: %s)\n"
             "                          How to encode the messages for writing to Kafka.\n"
             "  -u, --allow-unkeyed     Allow export of tables that don't have a primary key.\n"
@@ -197,8 +199,11 @@ void parse_options(producer_context_t context, int argc, char **argv) {
 
     if (!context->client->conninfo || optind < argc) usage();
 
-    if (!context->registry) {
+    if (context->output_format == OUTPUT_FORMAT_AVRO && !context->registry) {
         init_schema_registry(context, DEFAULT_SCHEMA_REGISTRY);
+    } else if (context->output_format == OUTPUT_FORMAT_JSON && context->registry) {
+        fprintf(stderr, "Specifying --schema-registry doesn't make sense for --output-format=json\n");
+        usage();
     }
 }
 

--- a/kafka/bottledwater.c
+++ b/kafka/bottledwater.c
@@ -41,6 +41,7 @@ typedef struct {
 typedef struct {
     client_context_t client;            /* The connection to Postgres */
     schema_registry_t registry;         /* Submits Avro schemas to schema registry */
+    table_mapper_t mapper;              /* TODO */
     char *brokers;                      /* Comma-separated list of host:port for Kafka brokers */
     transaction_info xact_list[MAX_IN_FLIGHT_TRANSACTIONS]; /* Circular buffer */
     int xact_head;                      /* Index into xact_list currently being received from PG */
@@ -289,6 +290,16 @@ static int on_table_schema(void *_context, uint64_t wal_pos, Oid relid,
             exit_nicely(context, 1);
         }
     }
+
+    table_metadata_t table = table_mapper_replace(context->mapper, relid);
+    /* TODO extract this to a more appropriate place */
+    table->topic_name = strdup(topic_name);
+    table->key_schema_id = entry->key_schema_id;
+    table->key_schema = avro_schema_incref(entry->key_schema);
+    table->row_schema_id = entry->row_schema_id;
+    table->row_schema = avro_schema_incref(entry->row_schema);
+    table->topic = entry->topic;
+
     return 0;
 }
 
@@ -336,17 +347,26 @@ int send_kafka_msg(producer_context_t context, uint64_t wal_pos, Oid relid,
 
     void *key = NULL, *val = NULL;
     size_t key_encoded_len, val_encoded_len;
+    rd_kafka_topic_t* topic;
 #ifdef JSON_MODE
-    topic_list_entry_t entry = json_encode_msg(context->registry, relid,
+    table_metadata_t table = table_mapper_lookup(context->mapper, relid);
+    if (!table) {
+        fprintf(stderr, "relid %" PRIu32 " has no registered schema", relid);
+        exit_nicely(context, 1);
+    }
+    topic = table->topic;
+
+    int err = json_encode_msg(table,
             key_bin, key_len, (char **) &key, &key_encoded_len, val_bin, val_len, (char **) &val, &val_encoded_len);
 
-    if (!entry) {
-        fprintf(stderr, "%s: %s\n", progname, context->registry->error);
+    if (err) {
+        fprintf(stderr, "%s: error %s encoding JSON for topic %s\n", progname, strerror(err), table->topic_name);
         exit_nicely(context, 1);
     }
 #else
     topic_list_entry_t entry = schema_registry_encode_msg(context->registry, relid,
             key_bin, key_len, &key, val_bin, val_len, &val);
+    topic = entry->topic;
     key_encoded_len = key_len + SCHEMA_REGISTRY_MESSAGE_PREFIX_LEN;
     val_encoded_len = val_len + SCHEMA_REGISTRY_MESSAGE_PREFIX_LEN;
 
@@ -358,7 +378,7 @@ int send_kafka_msg(producer_context_t context, uint64_t wal_pos, Oid relid,
 
     bool enqueued = false;
     while (!enqueued) {
-        int err = rd_kafka_produce(entry->topic, RD_KAFKA_PARTITION_UA, RD_KAFKA_MSG_F_FREE,
+        int err = rd_kafka_produce(topic, RD_KAFKA_PARTITION_UA, RD_KAFKA_MSG_F_FREE,
                 val, val == NULL ? 0 : val_encoded_len,
                 key, key == NULL ? 0 : key_encoded_len,
                 envelope);
@@ -497,6 +517,7 @@ producer_context_t init_producer(client_context_t client) {
 
     context->client = client;
     context->registry = schema_registry_new(DEFAULT_SCHEMA_REGISTRY);
+    context->mapper = table_mapper_new();
     context->brokers = DEFAULT_BROKER_LIST;
     context->kafka_conf = rd_kafka_conf_new();
     context->topic_conf = rd_kafka_topic_conf_new();
@@ -541,6 +562,7 @@ void exit_nicely(producer_context_t context, int status) {
         }
     }
 
+    table_mapper_free(context->mapper);
     schema_registry_free(context->registry);
     frame_reader_free(context->client->repl.frame_reader);
     db_client_free(context->client);

--- a/kafka/bottledwater.c
+++ b/kafka/bottledwater.c
@@ -56,8 +56,8 @@ typedef struct {
     rd_kafka_conf_t *kafka_conf;
     rd_kafka_topic_conf_t *topic_conf;
     rd_kafka_t *kafka;
-    table_mapper_t mapper;              /* TODO */
-    format_t output_format;             /* TODO */
+    table_mapper_t mapper;              /* Remembers topics and schemas for tables we've seen */
+    format_t output_format;             /* How to encode messages for writing to Kafka */
     char error[PRODUCER_CONTEXT_ERROR_LEN];
 } producer_context;
 

--- a/kafka/json.c
+++ b/kafka/json.c
@@ -1,4 +1,17 @@
-/* TODO docs */
+/* JSON encoding for messages written to Kafka.
+ *
+ * The JSON format is defined by libavro's avro_value_to_json function, which
+ * produces JSON as defined in the Avro spec:
+ * https://avro.apache.org/docs/1.7.7/spec.html#json_encoding
+ *
+ * Examples:
+ *
+ *  * {"id": {"int": 1}} // an integer key
+ *  * {"id": {"int": 3}, "title": {"string": "Man Bites Dog"}} // a row with two fields
+ *
+ * N.B. the output JSON does contain whitespace (as in the above examples), and
+ * so may be rejected by strict JSON parsers.
+ */
 
 #include "json.h"
 

--- a/kafka/json.c
+++ b/kafka/json.c
@@ -31,12 +31,12 @@ int json_encode_msg(table_metadata_t table,
     int err;
     err = avro_bin_to_json(table->key_schema, key_bin, key_len, key_out, key_len_out);
     if (err) {
-      fprintf(stderr, "json: error encoding key: %s\n", avro_strerror());
+      fprintf(stderr, "json: error encoding key\n");
       return err;
     }
     err = avro_bin_to_json(table->row_schema, row_bin, row_len, row_out, row_len_out);
     if (err) {
-      fprintf(stderr, "json: error encoding row: %s\n", avro_strerror());
+      fprintf(stderr, "json: error encoding row\n");
       return err;
     }
 
@@ -51,7 +51,8 @@ int avro_bin_to_json(avro_schema_t schema,
         *val_out = NULL;
         return 0;
     } else if (!schema) {
-        /* got a value where we didn't expect one, and no schema to decode it */
+        fprintf(stderr,
+            "json: got a value where we didn't expect one, and no schema to decode it\n");
         *val_out = NULL;
         return EINVAL;
     }

--- a/kafka/json.c
+++ b/kafka/json.c
@@ -8,9 +8,6 @@
  *
  *  * {"id": {"int": 1}} // an integer key
  *  * {"id": {"int": 3}, "title": {"string": "Man Bites Dog"}} // a row with two fields
- *
- * N.B. the output JSON does contain whitespace (as in the above examples), and
- * so may be rejected by strict JSON parsers.
  */
 
 #include "json.h"

--- a/kafka/json.c
+++ b/kafka/json.c
@@ -10,30 +10,24 @@ int avro_bin_to_json(avro_schema_t schema,
         char **val_out, size_t *val_len_out);
 
 
-topic_list_entry_t json_encode_msg(schema_registry_t registry, int64_t relid,
+int json_encode_msg(table_metadata_t table,
         const void *key_bin, size_t key_len,
         char **key_out, size_t *key_len_out,
         const void *row_bin, size_t row_len,
         char **row_out, size_t *row_len_out) {
-    topic_list_entry_t entry = topic_list_lookup(registry, relid);
-    if (!entry) {
-        registry_error(registry, "relid %" PRIu64 " has no registered schema", relid);
-        return NULL;
-    }
-
     int err;
-    err = avro_bin_to_json(entry->key_schema, key_bin, key_len, key_out, key_len_out);
+    err = avro_bin_to_json(table->key_schema, key_bin, key_len, key_out, key_len_out);
     if (err) {
-      registry_error(registry, "error %d encoding key", err);
-      return NULL;
+      fprintf(stderr, "json: error %d encoding key", err);
+      return err;
     }
-    err = avro_bin_to_json(entry->row_schema, row_bin, row_len, row_out, row_len_out);
+    err = avro_bin_to_json(table->row_schema, row_bin, row_len, row_out, row_len_out);
     if (err) {
-      registry_error(registry, "error %d encoding row", err);
-      return NULL;
+      fprintf(stderr, "json: error %d encoding row", err);
+      return err;
     }
 
-    return entry;
+    return 0;
 }
 
 

--- a/kafka/json.c
+++ b/kafka/json.c
@@ -18,12 +18,12 @@ int json_encode_msg(table_metadata_t table,
     int err;
     err = avro_bin_to_json(table->key_schema, key_bin, key_len, key_out, key_len_out);
     if (err) {
-      fprintf(stderr, "json: error %d encoding key", err);
+      fprintf(stderr, "json: error %s encoding key\n", avro_strerror());
       return err;
     }
     err = avro_bin_to_json(table->row_schema, row_bin, row_len, row_out, row_len_out);
     if (err) {
-      fprintf(stderr, "json: error %d encoding row", err);
+      fprintf(stderr, "json: error %s encoding row\n", avro_strerror());
       return err;
     }
 

--- a/kafka/json.c
+++ b/kafka/json.c
@@ -1,0 +1,83 @@
+/* TODO docs */
+
+#include "json.h"
+
+#include <avro.h>
+#include <stdio.h>
+
+int avro_bin_to_json(avro_schema_t schema,
+        const void *val_bin, size_t val_len,
+        char **val_out, size_t *val_len_out);
+
+
+topic_list_entry_t json_encode_msg(schema_registry_t registry, int64_t relid,
+        const void *key_bin, size_t key_len,
+        char **key_out, size_t *key_len_out,
+        const void *row_bin, size_t row_len,
+        char **row_out, size_t *row_len_out) {
+    topic_list_entry_t entry = topic_list_lookup(registry, relid);
+    if (!entry) {
+        registry_error(registry, "relid %" PRIu64 " has no registered schema", relid);
+        return NULL;
+    }
+
+    int err;
+    avro_schema_t schema = avro_schema_long();
+    err = avro_bin_to_json(schema, key_bin, key_len, key_out, key_len_out);
+    avro_schema_decref(schema);
+    if (err) {
+      registry_error(registry, "error %d encoding key", err);
+      return NULL;
+    }
+    schema = avro_schema_string();
+    err = avro_bin_to_json(schema, row_bin, row_len, row_out, row_len_out);
+    avro_schema_decref(schema);
+    if (err) {
+      registry_error(registry, "error %d encoding row", err);
+      return NULL;
+    }
+
+    return entry;
+}
+
+
+int avro_bin_to_json(avro_schema_t schema,
+        const void *val_bin, size_t val_len,
+        char **val_out, size_t *val_len_out) {
+    if (!val_bin) {
+        *val_out = NULL;
+        return 0;
+    }
+
+    avro_reader_t reader = avro_reader_memory(val_bin, val_len);
+
+    avro_value_iface_t *iface = avro_generic_class_from_schema(schema);
+    // TODO error handling?
+    avro_value_t value;
+    avro_generic_value_new(iface, &value);
+    // TODO error handling?
+
+    int err = avro_value_read(reader, &value);
+    if (err) {
+        avro_value_decref(&value);
+        avro_value_iface_decref(iface);
+        avro_reader_free(reader);
+        return err;
+    }
+
+    err = avro_value_to_json(&value, 1, val_out);
+    if (err) {
+        avro_value_decref(&value);
+        avro_value_iface_decref(iface);
+        avro_reader_free(reader);
+        return err;
+    }
+
+    *val_len_out = strlen(*val_out); // not including null terminator - to librdkafka it's just bytes
+
+    avro_value_decref(&value);
+    avro_value_iface_decref(iface);
+    avro_reader_free(reader);
+
+    return 0;
+}

--- a/kafka/json.h
+++ b/kafka/json.h
@@ -2,13 +2,10 @@
 #define JSON_H
 
 
-// TODO refactor so json doesn't depend on registry
-#include "registry.h"
-
-#include <librdkafka/rdkafka.h>
+#include "table_mapper.h"
 
 
-topic_list_entry_t json_encode_msg(schema_registry_t registry, int64_t relid,
+int json_encode_msg(table_metadata_t table,
         const void *key_bin, size_t key_len,
         char **key_out, size_t *key_len_out,
         const void *row_bin, size_t row_len,

--- a/kafka/json.h
+++ b/kafka/json.h
@@ -1,0 +1,18 @@
+#ifndef JSON_H
+#define JSON_H
+
+
+// TODO refactor so json doesn't depend on registry
+#include "registry.h"
+
+#include <librdkafka/rdkafka.h>
+
+
+topic_list_entry_t json_encode_msg(schema_registry_t registry, int64_t relid,
+        const void *key_bin, size_t key_len,
+        char **key_out, size_t *key_len_out,
+        const void *row_bin, size_t row_len,
+        char **row_out, size_t *row_len_out);
+
+
+#endif /* JSON_H */

--- a/kafka/registry.c
+++ b/kafka/registry.c
@@ -22,6 +22,7 @@
 
 #define CONTENT_TYPE "application/vnd.schemaregistry.v1+json"
 
+void schema_registry_set_url(schema_registry_t registry, char *url);
 void *add_schema_prefix(int schema_id, const void *avro_bin, size_t avro_len);
 static size_t registry_response_cb(void *data, size_t size, size_t nmemb, void *dest);
 int registry_parse_response(schema_registry_t registry, CURLcode result, char *resp_body,
@@ -44,9 +45,6 @@ schema_registry_t schema_registry_new(char *url) {
 
 /* Configures the URL for the schema registry. The argument is copied. */
 void schema_registry_set_url(schema_registry_t registry, char *url) {
-    if (registry->registry_url) {
-        free(registry->registry_url);
-    }
     registry->registry_url = strdup(url);
 
     // Strip trailing slash

--- a/kafka/registry.h
+++ b/kafka/registry.h
@@ -11,45 +11,25 @@
 #define SCHEMA_REGISTRY_ERROR_LEN 512
 
 typedef struct {
-    uint64_t relid;             /* Uniquely identifies a table, even when it is renamed */
-    char *topic_name;           /* Derived from schema record name, in turn derived from table name */
-    int key_schema_id;          /* Identifier for the current key schema, assigned by the registry */
-    avro_schema_t key_schema;   /* TODO */
-    int row_schema_id;          /* Identifier for the current row schema, assigned by the registry */
-    avro_schema_t row_schema;   /* TODO */
-    rd_kafka_topic_t *topic;    /* Kafka topic to which messages are produced */
-} topic_list_entry;
-
-typedef topic_list_entry *topic_list_entry_t;
-
-typedef struct {
     CURL *curl;                            /* HTTP client for making requests to schema registry */
     struct curl_slist *curl_headers;       /* HTTP headers for requests to schema registry */
     char curl_error[CURL_ERROR_SIZE];      /* Buffer for libcurl error messages */
     char error[SCHEMA_REGISTRY_ERROR_LEN]; /* Buffer for general error messages */
     char *registry_url;                    /* URL of server (set with schema_registry_set_url()) */
-    int num_topics;                        /* Number of topics in use */
-    int capacity;                          /* Allocated size of topics array */
-    topic_list_entry **topics;             /* Array of pointers to schema_list_entry structs */
 } schema_registry;
 
 typedef schema_registry *schema_registry_t;
 
 schema_registry_t schema_registry_new(char *url);
 void schema_registry_set_url(schema_registry_t registry, char *url);
-topic_list_entry_t schema_registry_encode_msg(schema_registry_t registry, int64_t relid,
-        const void *key_bin, size_t key_len, void **key_out,
-        const void *row_bin, size_t row_len, void **row_out);
-topic_list_entry_t schema_registry_update(schema_registry_t registry,
-        int64_t relid, const char *topic_name,
-        const char *key_schema_json, size_t key_schema_len,
-        const char *row_schema_json, size_t row_schema_len);
+int schema_registry_request(schema_registry_t registry, const char* name,
+        int is_key,
+        const char *schema_json, size_t schema_len,
+        int *schema_id_out);
+int schema_registry_encode_msg(int key_schema_id, int row_schema_id,
+        const void *key_bin, size_t key_len, void **key_out, size_t *key_len_out,
+        const void *row_bin, size_t row_len, void **row_out, size_t *row_len_out);
 void schema_registry_free(schema_registry_t reader);
-
-
-// TODO refactor since this is the wrong place to expose this
-topic_list_entry_t topic_list_lookup(schema_registry_t registry, int64_t relid);
-void registry_error(schema_registry_t registry, char *fmt, ...) __attribute__ ((format (printf, 2, 3)));
 
 
 #endif /* REGISTRY_H */

--- a/kafka/registry.h
+++ b/kafka/registry.h
@@ -3,6 +3,7 @@
 
 #include <librdkafka/rdkafka.h>
 #include <curl/curl.h>
+#include <avro.h>
 
 /* 5 bytes prefix is added by schema_registry_encode_msg(). */
 #define SCHEMA_REGISTRY_MESSAGE_PREFIX_LEN 5
@@ -13,7 +14,9 @@ typedef struct {
     uint64_t relid;             /* Uniquely identifies a table, even when it is renamed */
     char *topic_name;           /* Derived from schema record name, in turn derived from table name */
     int key_schema_id;          /* Identifier for the current key schema, assigned by the registry */
+    avro_schema_t key_schema;   /* TODO */
     int row_schema_id;          /* Identifier for the current row schema, assigned by the registry */
+    avro_schema_t row_schema;   /* TODO */
     rd_kafka_topic_t *topic;    /* Kafka topic to which messages are produced */
 } topic_list_entry;
 

--- a/kafka/registry.h
+++ b/kafka/registry.h
@@ -15,13 +15,12 @@ typedef struct {
     struct curl_slist *curl_headers;       /* HTTP headers for requests to schema registry */
     char curl_error[CURL_ERROR_SIZE];      /* Buffer for libcurl error messages */
     char error[SCHEMA_REGISTRY_ERROR_LEN]; /* Buffer for general error messages */
-    char *registry_url;                    /* URL of server (set with schema_registry_set_url()) */
+    char *registry_url;                    /* URL of server */
 } schema_registry;
 
 typedef schema_registry *schema_registry_t;
 
 schema_registry_t schema_registry_new(char *url);
-void schema_registry_set_url(schema_registry_t registry, char *url);
 int schema_registry_request(schema_registry_t registry, const char* name,
         int is_key,
         const char *schema_json, size_t schema_len,

--- a/kafka/registry.h
+++ b/kafka/registry.h
@@ -43,4 +43,10 @@ topic_list_entry_t schema_registry_update(schema_registry_t registry,
         const char *row_schema_json, size_t row_schema_len);
 void schema_registry_free(schema_registry_t reader);
 
+
+// TODO refactor since this is the wrong place to expose this
+topic_list_entry_t topic_list_lookup(schema_registry_t registry, int64_t relid);
+void registry_error(schema_registry_t registry, char *fmt, ...) __attribute__ ((format (printf, 2, 3)));
+
+
 #endif /* REGISTRY_H */

--- a/kafka/table_mapper.c
+++ b/kafka/table_mapper.c
@@ -1,0 +1,75 @@
+/* TODO docs */
+
+#include "table_mapper.h"
+
+
+table_metadata_t table_metadata_new(table_mapper_t mapper, Oid relid);
+void table_metadata_reset(table_metadata_t table);
+
+
+table_mapper_t table_mapper_new(void) {
+    table_mapper_t mapper = malloc(sizeof(table_mapper));
+    memset(mapper, 0, sizeof(table_mapper));
+
+    mapper->num_tables = 0;
+    mapper->capacity = 16;
+    mapper->tables = malloc(mapper->capacity * sizeof(void*));
+
+    return mapper;
+}
+
+table_metadata_t table_mapper_lookup(table_mapper_t mapper, Oid relid) {
+    for (int i = 0; i < mapper->num_tables; i++) {
+        table_metadata_t table = mapper->tables[i];
+        if (table->relid == relid) return table;
+    }
+    return NULL;
+}
+
+table_metadata_t table_mapper_replace(table_mapper_t mapper, Oid relid) {
+    table_metadata_t table = table_mapper_lookup(mapper, relid);
+    if (table) {
+        table_metadata_reset(table);
+        return table;
+    } else {
+        return table_metadata_new(mapper, relid);
+    }
+}
+
+void table_mapper_free(table_mapper_t mapper) {
+    for (int i = 0; i < mapper->num_tables; i++) {
+        table_metadata_t table = mapper->tables[i];
+        table_metadata_reset(table);
+        free(table);
+    }
+
+    free(mapper->tables);
+
+    free(mapper);
+}
+
+
+table_metadata_t table_metadata_new(table_mapper_t mapper, Oid relid) {
+    if (mapper->num_tables == mapper->capacity) {
+        mapper->capacity *= 4;
+        mapper->tables = realloc(mapper->tables, mapper->capacity * sizeof(void*));
+    }
+
+    table_metadata_t table = malloc(sizeof(table_metadata));
+    memset(table, 0, sizeof(table_metadata));
+    mapper->tables[mapper->num_tables] = table;
+    mapper->num_tables++;
+
+    table->relid = relid;
+
+    return table;
+}
+
+void table_metadata_reset(table_metadata_t table) {
+    /* TODO reenable this once registry's topic_list no longer owns topics
+    if (table->topic) rd_kafka_topic_destroy(table->topic);
+    */
+    if (table->row_schema) avro_schema_decref(table->row_schema);
+    if (table->key_schema) avro_schema_decref(table->key_schema);
+    if (table->topic_name) free(table->topic_name);
+}

--- a/kafka/table_mapper.c
+++ b/kafka/table_mapper.c
@@ -2,18 +2,29 @@
 
 #include "table_mapper.h"
 
+#include <stdarg.h>
+
 
 table_metadata_t table_metadata_new(table_mapper_t mapper, Oid relid);
-void table_metadata_reset(table_metadata_t table);
+void table_metadata_free(table_metadata_t table);
+
+void mapper_error(table_mapper_t mapper, char *fmt, ...) __attribute__ ((format (printf, 2, 3)));
 
 
-table_mapper_t table_mapper_new(void) {
+table_mapper_t table_mapper_new(
+        rd_kafka_t *kafka,
+        rd_kafka_topic_conf_t *topic_conf,
+        schema_registry_t registry) {
     table_mapper_t mapper = malloc(sizeof(table_mapper));
     memset(mapper, 0, sizeof(table_mapper));
 
     mapper->num_tables = 0;
     mapper->capacity = 16;
     mapper->tables = malloc(mapper->capacity * sizeof(void*));
+
+    mapper->kafka = kafka;
+    mapper->topic_conf = topic_conf;
+    mapper->registry = registry;
 
     return mapper;
 }
@@ -26,20 +37,90 @@ table_metadata_t table_mapper_lookup(table_mapper_t mapper, Oid relid) {
     return NULL;
 }
 
-table_metadata_t table_mapper_replace(table_mapper_t mapper, Oid relid) {
+table_metadata_t table_mapper_update(table_mapper_t mapper, Oid relid,
+        const char* topic_name,
+        const char* key_schema_json, size_t key_schema_len,
+        const char* row_schema_json, size_t row_schema_len) {
     table_metadata_t table = table_mapper_lookup(mapper, relid);
-    if (table) {
-        table_metadata_reset(table);
-        return table;
-    } else {
-        return table_metadata_new(mapper, relid);
+    if (!table) {
+        table = table_metadata_new(mapper, relid);
     }
+
+    /* TODO break this up into setter functions! */
+
+    if (!table->topic || strcmp(topic_name, rd_kafka_topic_name(table->topic))) {
+        if (table->topic) rd_kafka_topic_destroy(table->topic);
+
+        table->topic = rd_kafka_topic_new(mapper->kafka, topic_name,
+                rd_kafka_topic_conf_dup(mapper->topic_conf));
+        if (!table->topic) {
+            mapper_error(mapper, "Cannot open Kafka topic %s: %s", topic_name,
+                    rd_kafka_err2str(rd_kafka_errno2err(errno)));
+            return NULL;
+        }
+    }
+
+    int err;
+
+    int prev_key_schema_id = table->key_schema_id;
+    if (mapper->registry) {
+        err = schema_registry_request(mapper->registry, topic_name, 1,
+                key_schema_json, key_schema_len,
+                &table->key_schema_id);
+        if (err) {
+            mapper_error(mapper, "Failed to register key schema: %s", mapper->registry->error);
+            return NULL;
+        }
+    }
+    int prev_row_schema_id = table->row_schema_id;
+    if (mapper->registry) {
+        err = schema_registry_request(mapper->registry, topic_name, 0,
+                row_schema_json, row_schema_len,
+                &table->row_schema_id);
+        if (err) {
+            mapper_error(mapper, "Failed to register row schema: %s", mapper->registry->error);
+            return NULL;
+        }
+    }
+
+    avro_schema_t schema;
+    if (prev_key_schema_id == TABLE_MAPPER_SCHEMA_ID_MISSING || prev_key_schema_id != table->key_schema_id) {
+        if (key_schema_json) {
+            err = avro_schema_from_json_length(key_schema_json, key_schema_len, &schema);
+
+            if (err) {
+                mapper_error(mapper, "Could not parse key schema (%s)", avro_strerror());
+                return NULL;
+            }
+        } else {
+            schema = NULL;
+        }
+        if (table->key_schema) avro_schema_decref(table->key_schema);
+        table->key_schema = schema;
+    }
+
+    if (prev_row_schema_id == TABLE_MAPPER_SCHEMA_ID_MISSING || prev_row_schema_id != table->row_schema_id) {
+        if (row_schema_json) {
+            err = avro_schema_from_json_length(row_schema_json, row_schema_len, &schema);
+
+            if (err) {
+                mapper_error(mapper, "Could not parse row schema (%s)", avro_strerror());
+                return NULL;
+            }
+        } else {
+            schema = NULL;
+        }
+        if (table->row_schema) avro_schema_decref(table->row_schema);
+        table->row_schema = schema;
+    }
+
+    return table;
 }
 
 void table_mapper_free(table_mapper_t mapper) {
     for (int i = 0; i < mapper->num_tables; i++) {
         table_metadata_t table = mapper->tables[i];
-        table_metadata_reset(table);
+        table_metadata_free(table);
         free(table);
     }
 
@@ -61,15 +142,25 @@ table_metadata_t table_metadata_new(table_mapper_t mapper, Oid relid) {
     mapper->num_tables++;
 
     table->relid = relid;
+    table->key_schema_id = TABLE_MAPPER_SCHEMA_ID_MISSING;
+    table->row_schema_id = TABLE_MAPPER_SCHEMA_ID_MISSING;
 
     return table;
 }
 
-void table_metadata_reset(table_metadata_t table) {
-    /* TODO reenable this once registry's topic_list no longer owns topics
-    if (table->topic) rd_kafka_topic_destroy(table->topic);
-    */
+void table_metadata_free(table_metadata_t table) {
+    if (table->topic) {
+        rd_kafka_topic_destroy(table->topic);
+    }
     if (table->row_schema) avro_schema_decref(table->row_schema);
     if (table->key_schema) avro_schema_decref(table->key_schema);
-    if (table->topic_name) free(table->topic_name);
+}
+
+
+/* Updates the mapper's statically allocated error buffer with a message. */
+void mapper_error(table_mapper_t mapper, char *fmt, ...) {
+    va_list args;
+    va_start(args, fmt);
+    vsnprintf(mapper->error, TABLE_MAPPER_ERROR_LEN, fmt, args);
+    va_end(args);
 }

--- a/kafka/table_mapper.h
+++ b/kafka/table_mapper.h
@@ -1,0 +1,36 @@
+#ifndef TABLE_MAPPER_H
+#define TABLE_MAPPER_H
+
+#include <avro.h>
+#include <librdkafka/rdkafka.h>
+#include <postgresql/postgres_ext.h>
+
+
+typedef struct {
+    Oid relid;                  /* Uniquely identifies a table, even when it is renamed */
+    char *topic_name;           /* Derived from schema record name, in turn derived from table name */
+    int key_schema_id;          /* Identifier for the current key schema, assigned by the registry */
+    avro_schema_t key_schema;   /* Schema to use for parsing key values */
+    int row_schema_id;          /* Identifier for the current row schema, assigned by the registry */
+    avro_schema_t row_schema;   /* Schema to use for parsing row values */
+    rd_kafka_topic_t *topic;    /* Kafka topic to which messages are produced */
+} table_metadata;
+
+typedef table_metadata *table_metadata_t;
+
+
+typedef struct {
+    int num_tables;           /* Number of tables known */
+    int capacity;             /* Allocated size of tables array */
+    table_metadata **tables;  /* Array of pointers to table_metadata structs */
+} table_mapper;
+
+typedef table_mapper *table_mapper_t;
+
+table_mapper_t table_mapper_new(void);
+table_metadata_t table_mapper_lookup(table_mapper_t mapper, Oid relid);
+table_metadata_t table_mapper_replace(table_mapper_t mapper, Oid relid);
+void table_mapper_free(table_mapper_t mapper);
+
+
+#endif /* TABLE_MAPPER_H */

--- a/kafka/table_mapper.h
+++ b/kafka/table_mapper.h
@@ -1,35 +1,50 @@
 #ifndef TABLE_MAPPER_H
 #define TABLE_MAPPER_H
 
+#include "registry.h"
+
 #include <avro.h>
 #include <librdkafka/rdkafka.h>
 #include <postgresql/postgres_ext.h>
 
 
+#define TABLE_MAPPER_SCHEMA_ID_MISSING (-1)
+#define TABLE_MAPPER_ERROR_LEN 512
+
+
 typedef struct {
     Oid relid;                  /* Uniquely identifies a table, even when it is renamed */
-    char *topic_name;           /* Derived from schema record name, in turn derived from table name */
+    rd_kafka_topic_t *topic;    /* Kafka topic to which messages are produced */
     int key_schema_id;          /* Identifier for the current key schema, assigned by the registry */
     avro_schema_t key_schema;   /* Schema to use for parsing key values */
     int row_schema_id;          /* Identifier for the current row schema, assigned by the registry */
     avro_schema_t row_schema;   /* Schema to use for parsing row values */
-    rd_kafka_topic_t *topic;    /* Kafka topic to which messages are produced */
 } table_metadata;
 
 typedef table_metadata *table_metadata_t;
 
 
 typedef struct {
-    int num_tables;           /* Number of tables known */
-    int capacity;             /* Allocated size of tables array */
-    table_metadata **tables;  /* Array of pointers to table_metadata structs */
+    char error[TABLE_MAPPER_ERROR_LEN]; /* Buffer for error messages */
+    rd_kafka_t *kafka;                  /* Reference to the Kafka connection (so we can create topics) */
+    rd_kafka_topic_conf_t *topic_conf;  /* Reference to the Kafka topic configuration */
+    schema_registry_t registry;         /* Reference to the schema registry client */
+    int num_tables;                     /* Number of tables known */
+    int capacity;                       /* Allocated size of tables array */
+    table_metadata **tables;            /* Array of pointers to table_metadata structs */
 } table_mapper;
 
 typedef table_mapper *table_mapper_t;
 
-table_mapper_t table_mapper_new(void);
+table_mapper_t table_mapper_new(
+        rd_kafka_t *kafka,
+        rd_kafka_topic_conf_t *topic_conf,
+        schema_registry_t registry);
 table_metadata_t table_mapper_lookup(table_mapper_t mapper, Oid relid);
-table_metadata_t table_mapper_replace(table_mapper_t mapper, Oid relid);
+table_metadata_t table_mapper_update(table_mapper_t mapper, Oid relid,
+        const char* topic_name,
+        const char* key_schema_json, size_t key_schema_len,
+        const char* row_schema_json, size_t row_schema_len);
 void table_mapper_free(table_mapper_t mapper);
 
 

--- a/kafka/table_mapper.h
+++ b/kafka/table_mapper.h
@@ -16,9 +16,9 @@ typedef struct {
     Oid relid;                  /* Uniquely identifies a table, even when it is renamed */
     rd_kafka_topic_t *topic;    /* Kafka topic to which messages are produced */
     int key_schema_id;          /* Identifier for the current key schema, assigned by the registry */
-    avro_schema_t key_schema;   /* Schema to use for parsing key values */
+    avro_schema_t key_schema;   /* Schema to use for converting key values to JSON */
     int row_schema_id;          /* Identifier for the current row schema, assigned by the registry */
-    avro_schema_t row_schema;   /* Schema to use for parsing row values */
+    avro_schema_t row_schema;   /* Schema to use for converting row values to JSON */
 } table_metadata;
 
 typedef table_metadata *table_metadata_t;


### PR DESCRIPTION
This adds a JSON encoding for the messages Bottled Water sends to Kafka, as an alternative to the existing Avro format.  If using this encoding, no schema registry is required.  This is proposed as an implementation for #15.

It also adds a new command-line option `--output-format=[avro|json]` to select the encoding at startup time.

Avro remains the default for backward compatibility, although I think there's an argument to be made (in a separate PR) for changing that, so that the default configuration could run without a schema registry.

### Design

As proposed in #15, this doesn't change the framing protocol between the Postgres extension and the client daemon, which remains Avro.  This means that in JSON mode, the client is no longer simply passing through bytes it received from the extension, but now needs to parse the binary-encoded Avro and convert it to JSON.

This is solved by keeping track of the Avro schemas corresponding to each table.  The client was already keeping track of the topics and registered schema ids for each table, so I refactored that mapping to also remember the actual Avro schemas (as well as the schema ids).  I extracted the mapping from kafka/registry.c into its own component: [kafka/table_mapper.c](https://github.com/samstokes/bottledwater-pg/blob/json/kafka/table_mapper.c).

### Message format

The JSON format is defined by libavro's `avro_value_to_json` function, which produces the [Avro JSON encoding](https://avro.apache.org/docs/1.7.7/spec.html#json_encoding) as defined in the Avro spec.

Examples:

 * `{"id": {"int": 1}}` // an integer key
 * `{"id": {"int": 3}, "title": {"string": "Man Bites Dog"}}` // a row with two fields

I think there's room to improve on the JSON format - the "type annotations" are unwieldy and confusing (though informative), and it contains whitespace, as in the above examples, and so may be rejected by strict JSON parsers.  I would suggest labelling the format as experimental and subject to change, but the same already applies to the Avro format (e.g. #5, #35), and indeed Bottled Water itself already carries an "early software" caveat, so I think that may be redundant.

### Schema registry in JSON mode

I chose to make it an error to specify `--schema-registry` if `--output-format=json`, in order to simplify the configuration space: you either have Avro with a registry, or JSON without.  This assumption is only enforced at startup, not deeply baked into the code (table_mapper.c will operate correctly whether or not a registry is configured).  We might imagine in the future supporting multiple output formats in the same BW instance (maybe with some kind of configuration file mapping tables to topics and formats, with e.g. a `posts_json` topic and a `posts_avro` topic).