### PR TITLE
Support a configurable topic name prefix

### DIFF
--- a/kafka/bottledwater.c
+++ b/kafka/bottledwater.c
@@ -611,7 +611,8 @@ void start_producer(producer_context_t context) {
     context->mapper = table_mapper_new(
             context->kafka,
             context->topic_conf,
-            context->registry);
+            context->registry,
+            NULL);
 
     fprintf(stderr,
             "Writing messages to Kafka in %s format\n",

--- a/kafka/bottledwater.c
+++ b/kafka/bottledwater.c
@@ -58,6 +58,7 @@ typedef struct {
     rd_kafka_t *kafka;
     table_mapper_t mapper;              /* Remembers topics and schemas for tables we've seen */
     format_t output_format;             /* How to encode messages for writing to Kafka */
+    char *topic_prefix;                 /* String to be prepended to all topic names */
     char error[PRODUCER_CONTEXT_ERROR_LEN];
 } producer_context;
 
@@ -133,6 +134,10 @@ void usage() {
             "  -u, --allow-unkeyed     Allow export of tables that don't have a primary key.\n"
             "                          This is disallowed by default, because updates and\n"
             "                          deletes need a primary key to identify their row.\n"
+            "  -p, --topic-prefix=prefix\n"
+            "                          String to prepend to all topic names.\n"
+            "                          e.g. with --topic-prefix=postgres, updates from table\n"
+            "                          'users' will be written to topic 'postgres-users'.\n"
             "  -C, --kafka-config property=value\n"
             "                          Set global configuration property for Kafka producer\n"
             "                          (see --config-help for list of properties).\n"
@@ -159,6 +164,7 @@ void parse_options(producer_context_t context, int argc, char **argv) {
         {"schema-registry", required_argument, NULL, 'r'},
         {"output-format",   required_argument, NULL, 'f'},
         {"allow-unkeyed",   no_argument,       NULL, 'u'},
+        {"topic-prefix",    required_argument, NULL, 'p'},
         {"kafka-config",    required_argument, NULL, 'C'},
         {"topic-config",    required_argument, NULL, 'T'},
         {"config-help",     no_argument,       NULL,  1 },
@@ -169,7 +175,7 @@ void parse_options(producer_context_t context, int argc, char **argv) {
 
     int option_index;
     while (true) {
-        int c = getopt_long(argc, argv, "d:s:b:r:f:uC:T:", options, &option_index);
+        int c = getopt_long(argc, argv, "d:s:b:r:f:up:C:T:", options, &option_index);
         if (c == -1) break;
 
         switch (c) {
@@ -190,6 +196,9 @@ void parse_options(producer_context_t context, int argc, char **argv) {
                 break;
             case 'u':
                 context->client->allow_unkeyed = true;
+                break;
+            case 'p':
+                context->topic_prefix = strdup(optarg);
                 break;
             case 'C':
                 set_kafka_config(context, optarg, parse_config_option(optarg));
@@ -612,7 +621,7 @@ void start_producer(producer_context_t context) {
             context->kafka,
             context->topic_conf,
             context->registry,
-            NULL);
+            context->topic_prefix);
 
     fprintf(stderr,
             "Writing messages to Kafka in %s format\n",
@@ -630,6 +639,7 @@ void exit_nicely(producer_context_t context, int status) {
         }
     }
 
+    if (context->topic_prefix) free(context->topic_prefix);
     table_mapper_free(context->mapper);
     if (context->registry) schema_registry_free(context->registry);
     frame_reader_free(context->client->repl.frame_reader);

--- a/kafka/table_mapper.c
+++ b/kafka/table_mapper.c
@@ -80,9 +80,9 @@ table_metadata_t table_mapper_update(table_mapper_t mapper, Oid relid,
         const char* row_schema_json, size_t row_schema_len) {
     table_metadata_t table = table_mapper_lookup(mapper, relid);
     if (table) {
-        logf("Updating metadata for table %" PRIu32 " (topic \"%s\")\n", relid, table_name);
+        logf("Updating metadata for table %s (relid %" PRIu32 ")\n", table_name, relid);
     } else {
-        logf("Registering metadata for table %" PRIu32 " (topic \"%s\")\n", relid, table_name);
+        logf("Registering metadata for table %s (relid %" PRIu32 ")\n", table_name, relid);
         table = table_metadata_new(mapper, relid);
     }
 

--- a/kafka/table_mapper.c
+++ b/kafka/table_mapper.c
@@ -139,14 +139,14 @@ table_metadata_t table_metadata_new(table_mapper_t mapper, Oid relid) {
 int table_metadata_update_topic(table_mapper_t mapper, table_metadata_t table, const char* table_name) {
     const char* prev_table_name = table->table_name;
 
-    if (!table->topic) {
-        logf("Registering table \"%s\" for relid %" PRIu32 "\n", table_name, table->relid);
-    } else if (strcmp(table_name, prev_table_name)) {
-        logf("Registering new table (was \"%s\", now \"%s\") for relid %" PRIu32 "\n", prev_table_name, table_name, table->relid);
+    if (table->topic) {
+        if (strcmp(table_name, prev_table_name)) {
+            logf("Registering new table (was \"%s\", now \"%s\") for relid %" PRIu32 "\n", prev_table_name, table_name, table->relid);
 
-        free(table->table_name);
-        rd_kafka_topic_destroy(table->topic);
-    } else return 0; // table name didn't change, nothing to do
+            free(table->table_name);
+            rd_kafka_topic_destroy(table->topic);
+        } else return 0; // table name didn't change, nothing to do
+    }
 
     table->table_name = strdup(table_name);
 

--- a/kafka/table_mapper.h
+++ b/kafka/table_mapper.h
@@ -10,10 +10,13 @@
 
 #define TABLE_MAPPER_SCHEMA_ID_MISSING (-1)
 #define TABLE_MAPPER_ERROR_LEN 512
+#define TABLE_MAPPER_MAX_TOPIC_LEN (256 + 1)
+#define TABLE_MAPPER_TOPIC_PREFIX_DELIMITER '-'
 
 
 typedef struct {
     Oid relid;                  /* Uniquely identifies a table, even when it is renamed */
+    char *table_name;           /* Name of the table in Postgres */
     rd_kafka_topic_t *topic;    /* Kafka topic to which messages are produced */
     int key_schema_id;          /* Identifier for the current key schema, assigned by the registry */
     avro_schema_t key_schema;   /* Schema to use for converting key values to JSON */
@@ -29,6 +32,7 @@ typedef struct {
     rd_kafka_t *kafka;                  /* Reference to the Kafka connection (so we can create topics) */
     rd_kafka_topic_conf_t *topic_conf;  /* Reference to the Kafka topic configuration */
     schema_registry_t registry;         /* Reference to the schema registry client */
+    char *topic_prefix;                 /* String to be prepended to all topic names */
     int num_tables;                     /* Number of tables known */
     int capacity;                       /* Allocated size of tables array */
     table_metadata **tables;            /* Array of pointers to table_metadata structs */
@@ -39,10 +43,11 @@ typedef table_mapper *table_mapper_t;
 table_mapper_t table_mapper_new(
         rd_kafka_t *kafka,
         rd_kafka_topic_conf_t *topic_conf,
-        schema_registry_t registry);
+        schema_registry_t registry,
+        const char *topic_prefix);
 table_metadata_t table_mapper_lookup(table_mapper_t mapper, Oid relid);
 table_metadata_t table_mapper_update(table_mapper_t mapper, Oid relid,
-        const char* topic_name,
+        const char* table_name,
         const char* key_schema_json, size_t key_schema_len,
         const char* row_schema_json, size_t row_schema_len);
 void table_mapper_free(table_mapper_t mapper);


### PR DESCRIPTION
Bottled Water produces to one topic for each Postgres table, where the topic name is equal to the table name. This presents a couple of challenges:

 * if the Kafka broker is being used for other purposes, topic names may collide
 * if a consumer wants to consume all tables, it can do so using a topic regex, but currently that regex would have to be `/.*/`, which could lead to consuming unintended topics (e.g. metadata topics such as used internally by the schema registry, Samza jobs etc).

Support for [namespaces in Kafka](https://cwiki.apache.org/confluence/display/KAFKA/KIP-37+-+Add+Namespaces+to+Kafka) has been proposed that would help with these problems, but it's still under discussion.

As a solution in the meantime, this adds a `--topic-prefix=SOME_PREFIX` option to Bottled Water that it would prepend to all topic names.  Anticipated uses could be:

 * `--topic-prefix=bottledwater` - to simply prevent collisions, and allow consuming all tables via the regex `/bottledwater.*/`
 * `--topic-prefix=DATABASE_NAME` - if you want to stream several databases into the same Kafka broker, using a separate BW instance for each database.