### PR TITLE
Upgrade build to Postgres 9.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ a data warehouse, calculate analytics, monitor it for fraud, and so on.
 How it works
 ------------
 
-Bottled Water uses the [logical decoding](http://www.postgresql.org/docs/9.4/static/logicaldecoding.html)
+Bottled Water uses the [logical decoding](http://www.postgresql.org/docs/9.5/static/logicaldecoding.html)
 feature (introduced in PostgreSQL 9.4) to extract a consistent snapshot and a continuous stream
 of change events from a database. The data is extracted at a row level, and encoded using
 [Avro](http://avro.apache.org/). A client program connects to your database, extracts this data,
@@ -79,7 +79,7 @@ The `postgres-bw` image extends the
 Bottled Water support. However, before Bottled Water can be used, it first needs to be
 enabled. To do this, start a `psql` shell for the Postgres database:
 
-    $ docker run -it --rm --link postgres:postgres postgres:9.4 sh -c \
+    $ docker run -it --rm --link postgres:postgres postgres:9.5 sh -c \
         'exec psql -h "$POSTGRES_PORT_5432_TCP_ADDR" -p "$POSTGRES_PORT_5432_TCP_PORT" -U postgres'
 
 When the prompt appears, enable the `bottledwater` extension, and create a database with
@@ -121,9 +121,9 @@ To compile Bottled Water is just a matter of:
 
 For that to work, you need the following dependencies installed:
 
-* [PostgreSQL 9.4](http://www.postgresql.org/) development libraries (PGXS and libpq).
+* [PostgreSQL 9.5](http://www.postgresql.org/) development libraries (PGXS and libpq).
   (Homebrew: `brew install postgresql`;
-  Ubuntu: `sudo apt-get install postgresql-server-dev-9.4 libpq-dev`)
+  Ubuntu: `sudo apt-get install postgresql-server-dev-9.5 libpq-dev`)
 * [libsnappy](https://code.google.com/p/snappy/), a dependency of Avro.
   (Homebrew: `brew install snappy`; Ubuntu: `sudo apt-get install libsnappy-dev`)
 * [avro-c](http://avro.apache.org/), the C implementation of Avro.

--- a/build/Dockerfile.build
+++ b/build/Dockerfile.build
@@ -22,7 +22,7 @@ RUN apt-get update && \
         libpq5 \
         libpq-dev \
         pkg-config \
-		postgresql-server-dev-9.5
+        postgresql-server-dev-9.5
 
 # Avro
 RUN curl -o /root/avro-c-1.7.7.tar.gz -SL http://archive.apache.org/dist/avro/avro-1.7.7/c/avro-c-1.7.7.tar.gz && \

--- a/build/Dockerfile.build
+++ b/build/Dockerfile.build
@@ -10,24 +10,19 @@
 # See the Makefile and the other Dockerfiles in this directory for more
 # detail on how the build artifacts are used.
 
-FROM postgres:9.4
+FROM postgres:9.5
 
 RUN apt-get update && \
-    # --force-yes is needed because we are downgrading libpq5 to $PG_VERSION
-    # (set by the postgres:9.4 Docker image).  Confusingly the postgres:9.4
-    # Docker image includes libpq5 version 9.5.x, which we are not yet
-    # compatible with, even though the Postgres version (and $PG_VERSION) are
-    # 9.4.x.
-    apt-get install -y --force-yes \
+    apt-get install -y \
         build-essential \
         cmake \
         curl \
         libcurl4-openssl-dev \
         libjansson-dev \
-        libpq5=${PG_VERSION} \
-        libpq-dev=${PG_VERSION} \
+        libpq5 \
+        libpq-dev \
         pkg-config \
-        postgresql-server-dev-9.4=${PG_VERSION}
+		postgresql-server-dev-9.5
 
 # Avro
 RUN curl -o /root/avro-c-1.7.7.tar.gz -SL http://archive.apache.org/dist/avro/avro-1.7.7/c/avro-c-1.7.7.tar.gz && \
@@ -48,6 +43,6 @@ RUN curl -o /root/librdkafka-0.9.0.tar.gz -SL https://github.com/edenhill/librdk
 COPY . /root/bottledwater
 RUN cd /root/bottledwater && \
     make clean && make && make install && cd / && \
-    tar czf bottledwater-ext.tar.gz usr/lib/postgresql/9.4/lib/bottledwater.so usr/share/postgresql/9.4/extension/bottledwater* && \
+    tar czf bottledwater-ext.tar.gz usr/lib/postgresql/9.5/lib/bottledwater.so usr/share/postgresql/9.5/extension/bottledwater* && \
     cp /root/bottledwater/kafka/bottledwater /root/bottledwater/client/bwtest /usr/local/bin && \
     tar czf bottledwater-bin.tar.gz usr/local/bin/bottledwater usr/local/bin/bwtest

--- a/build/Dockerfile.client
+++ b/build/Dockerfile.client
@@ -8,7 +8,7 @@
 #   docker build -f build/Dockerfile.client -t confluent/bottledwater:0.1 build
 #   docker run -d --name bottledwater --link postgres:postgres --link kafka:kafka --link schema-registry:schema-registry confluent/bottledwater:0.1
 
-FROM postgres:9.4
+FROM postgres:9.5
 
 RUN apt-get update && \
     apt-get upgrade -y && \

--- a/build/Dockerfile.postgres
+++ b/build/Dockerfile.postgres
@@ -11,14 +11,14 @@
 #
 # To connect to the running container with psql:
 #
-#   docker run -it --rm --link postgres:postgres postgres:9.4 \
+#   docker run -it --rm --link postgres:postgres postgres:9.5 \
 #     sh -c 'exec psql -h "$POSTGRES_PORT_5432_TCP_ADDR" -p "$POSTGRES_PORT_5432_TCP_PORT" -U postgres'
 #
 # In the psql session, type the following to enable the plugin:
 #
 #   create extension bottledwater;
 
-FROM postgres:9.4
+FROM postgres:9.5
 
 ADD bottledwater-ext.tar.gz /
 ADD avro-1.7.7.tar.gz /

--- a/kafka/table_mapper.h
+++ b/kafka/table_mapper.h
@@ -5,7 +5,7 @@
 
 #include <avro.h>
 #include <librdkafka/rdkafka.h>
-#include <postgresql/postgres_ext.h>
+#include <postgres_ext.h>
 
 
 #define TABLE_MAPPER_SCHEMA_ID_MISSING (-1)


### PR DESCRIPTION
This updates the Docker build to Postgres 9.5.1. Despite the reports of problems in #44 and #49, it builds and runs fine for me, without any code changes. Perhaps there was an issue in 9.5.0 that got fixed in 9.5.1? Could others give it a try please?