### PR TITLE
Simplify dev setup using Docker Compose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,9 @@ clean:
 
 docker: docker-client docker-postgres
 
+docker-compose: docker
+	docker-compose build
+
 tmp:
 	mkdir tmp
 

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ tmp/%: build/% tmp
 docker-build:
 	docker build -f build/Dockerfile.build -t bwbuild:$(DOCKER_TAG) .
 
-docker-client: tmp/Dockerfile.client tmp/avro-1.8.0.tar.gz tmp/librdkafka-0.9.0.tar.gz tmp/bottledwater-bin.tar.gz
+docker-client: tmp/Dockerfile.client tmp/avro-1.8.0.tar.gz tmp/librdkafka-0.9.0.tar.gz tmp/bottledwater-bin.tar.gz tmp/bottledwater-docker-wrapper.sh
 	docker build -f $< -t local-bottledwater:$(DOCKER_TAG) tmp
 
 docker-postgres: tmp/Dockerfile.postgres tmp/bottledwater-ext.tar.gz tmp/avro-1.8.0.tar.gz tmp/replication-config.sh

--- a/README.md
+++ b/README.md
@@ -93,12 +93,12 @@ You can keep the psql terminal open, and run the following in a new terminal.
 The next step is to start the Bottled Water client, which relays data from Postgres to Kafka.
 You start it like this:
 
-    $ docker-compose up -d bottledwater
+    $ docker-compose up -d bottledwater-json
 
-You can run `docker-compose logs bottledwater` to see what it's doing. Now Bottled Water has taken
-the snapshot, and continues to watch Postgres for any data changes. You can see the data
-that has been extracted from Postgres by consuming from Kafka (the topic name `test` must
-match up with the name of the table you created earlier):
+You can run `docker-compose logs bottledwater-json` to see what it's doing. Now Bottled
+Water has taken the snapshot, and continues to watch Postgres for any data changes. You can
+see the data that has been extracted from Postgres by consuming from Kafka (the topic name
+`test` must match up with the name of the table you created earlier):
 
     $ docker-compose run --rm kafka-avro-console-consumer --from-beginning --topic test
 

--- a/build/Dockerfile.client
+++ b/build/Dockerfile.client
@@ -18,10 +18,11 @@ ADD avro-1.8.0.tar.gz /
 ADD librdkafka-0.9.0.tar.gz /
 ADD bottledwater-bin.tar.gz /
 
+COPY bottledwater-docker-wrapper.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/bottledwater-docker-wrapper.sh
+
 RUN cp /usr/local/lib/librdkafka.so.1 /usr/lib/x86_64-linux-gnu && \
     cp /usr/local/lib/libavro.so.23.0.0 /usr/lib/x86_64-linux-gnu
 
-CMD /usr/local/bin/bottledwater --output-format avro \
-    --schema-registry http://${SCHEMA_REGISTRY_PORT_8081_TCP_ADDR}:${SCHEMA_REGISTRY_PORT_8081_TCP_PORT} \
-    --postgres "hostaddr=${POSTGRES_PORT_5432_TCP_ADDR} port=${POSTGRES_PORT_5432_TCP_PORT} dbname=postgres user=postgres" \
-    --broker ${KAFKA_PORT_9092_TCP_ADDR}:${KAFKA_PORT_9092_TCP_PORT}
+ENTRYPOINT ["/usr/local/bin/bottledwater-docker-wrapper.sh"]
+CMD ["--output-format=json", "--allow-unkeyed"]

--- a/build/bottledwater-docker-wrapper.sh
+++ b/build/bottledwater-docker-wrapper.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+POSTGRES_CONNECTION_STRING="hostaddr=$POSTGRES_PORT_5432_TCP_ADDR port=$POSTGRES_PORT_5432_TCP_PORT dbname=postgres user=postgres"
+KAFKA_BROKER="$KAFKA_PORT_9092_TCP_ADDR:$KAFKA_PORT_9092_TCP_PORT"
+
+if [ -n "$SCHEMA_REGISTRY_PORT_8081_TCP_ADDR" ]; then
+  SCHEMA_REGISTRY_URL="http://${SCHEMA_REGISTRY_PORT_8081_TCP_ADDR}:${SCHEMA_REGISTRY_PORT_8081_TCP_PORT}"
+
+  schema_registry_opts="--schema-registry=$SCHEMA_REGISTRY_URL"
+else
+  schema_registry_opts=
+fi
+
+exec /usr/local/bin/bottledwater \
+    --postgres="$POSTGRES_CONNECTION_STRING" \
+    --broker="$KAFKA_BROKER" \
+    $schema_registry_opts \
+    "$@"
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,50 @@
+zookeeper:
+  image: confluent/zookeeper
+  hostname: zookeeper
+  ports:
+    - '42181:2181'
+    - '42888:2888'
+    - '43888:3888'
+kafka:
+  image: confluent/kafka
+  hostname: kafka
+  links:
+    - zookeeper
+  environment:
+    KAFKA_LOG_CLEANUP_POLICY: compact
+  ports:
+    - '49092:9092'
+schema-registry:
+  image: confluent/schema-registry
+  hostname: schema-registry
+  links:
+    - zookeeper
+    - kafka
+  ports:
+    - '48081:8081'
+  environment:
+    SCHEMA_REGISTRY_AVRO_COMPATIBILITY_LEVEL: none
+postgres:
+  image: confluent/postgres-bw:0.1
+  hostname: postgres
+  ports:
+    - '45432:5432'
+bottledwater:
+  image: confluent/bottledwater:0.1
+  hostname: bottledwater
+  links:
+    - postgres
+    - kafka
+    - schema-registry
+psql:
+  image: postgres:9.4
+  links:
+    - postgres
+  command: 'sh -c ''exec psql -h "$POSTGRES_PORT_5432_TCP_ADDR" -p "$POSTGRES_PORT_5432_TCP_PORT" -U postgres'''
+kcc:
+  image: confluent/tools
+  links:
+    - zookeeper
+    - kafka
+    - schema-registry
+  entrypoint: ['/confluent-tools.sh', 'kafka-avro-console-consumer']

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,11 @@
+# N.B. assumes you have set the environment variable
+# KAFKA_ADVERTISED_HOST_NAME, in the environment of the host where you are
+# running docker-compose, to the IP address of the Docker host.
+#
+# You can determine the Docker host IP with a command like (on Linux):
+#
+#   ip -o -4 addr show dev docker0 | awk '{sub(/\/[0-9]+$/, "", $4); print $4}'
+
 zookeeper:
   image: confluent/zookeeper
   hostname: zookeeper
@@ -10,6 +18,7 @@ kafka:
     - zookeeper
   environment:
     KAFKA_LOG_CLEANUP_POLICY: compact
+    KAFKA_ADVERTISED_HOST_NAME:
   ports:
     - '9092:9092'
 schema-registry:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,16 +14,6 @@ kafka:
     KAFKA_LOG_CLEANUP_POLICY: compact
   ports:
     - '49092:9092'
-schema-registry:
-  image: confluent/schema-registry
-  hostname: schema-registry
-  links:
-    - zookeeper
-    - kafka
-  ports:
-    - '48081:8081'
-  environment:
-    SCHEMA_REGISTRY_AVRO_COMPATIBILITY_LEVEL: none
 postgres:
   build: ./tmp
   dockerfile: Dockerfile.postgres
@@ -37,16 +27,14 @@ bottledwater:
   links:
     - postgres
     - kafka
-    - schema-registry
 psql:
   image: postgres:9.4
   links:
     - postgres
   command: 'sh -c ''exec psql -h "$POSTGRES_PORT_5432_TCP_ADDR" -p "$POSTGRES_PORT_5432_TCP_PORT" -U postgres'''
-kcc:
+kafka-tools:
   image: confluent/tools
   links:
     - zookeeper
     - kafka
-    - schema-registry
-  entrypoint: ['/confluent-tools.sh', 'kafka-avro-console-consumer']
+  entrypoint: /confluent-tools.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,12 +25,14 @@ schema-registry:
   environment:
     SCHEMA_REGISTRY_AVRO_COMPATIBILITY_LEVEL: none
 postgres:
-  image: local-postgres-bw:dev
+  build: ./tmp
+  dockerfile: Dockerfile.postgres
   hostname: postgres
   ports:
     - '45432:5432'
 bottledwater:
-  image: local-bottledwater:dev
+  build: ./tmp
+  dockerfile: Dockerfile.client
   hostname: bottledwater
   links:
     - postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ zookeeper:
   image: confluent/zookeeper
   hostname: zookeeper
   ports:
-    - '42181:2181'
+    - '2181:2181'
 kafka:
   image: confluent/kafka
   hostname: kafka
@@ -11,7 +11,7 @@ kafka:
   environment:
     KAFKA_LOG_CLEANUP_POLICY: compact
   ports:
-    - '49092:9092'
+    - '9092:9092'
 schema-registry:
   image: confluent/schema-registry
   hostname: schema-registry

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,24 +14,51 @@ kafka:
     KAFKA_LOG_CLEANUP_POLICY: compact
   ports:
     - '49092:9092'
+schema-registry:
+  image: confluent/schema-registry
+  hostname: schema-registry
+  links:
+    - zookeeper
+    - kafka
+  ports:
+    - '48081:8081'
+  environment:
+    SCHEMA_REGISTRY_AVRO_COMPATIBILITY_LEVEL: none
 postgres:
   build: ./tmp
   dockerfile: Dockerfile.postgres
   hostname: postgres
   ports:
     - '45432:5432'
-bottledwater:
+bottledwater-json:
   build: ./tmp
   dockerfile: Dockerfile.client
   hostname: bottledwater
   links:
     - postgres
     - kafka
+  command: --output-format=json --allow-unkeyed
+bottledwater-avro:
+  build: ./tmp
+  dockerfile: Dockerfile.client
+  hostname: bottledwater
+  links:
+    - postgres
+    - kafka
+    - schema-registry
+  command: --output-format=avro --allow-unkeyed
 psql:
   image: postgres:9.4
   links:
     - postgres
   command: 'sh -c ''exec psql -h "$POSTGRES_PORT_5432_TCP_ADDR" -p "$POSTGRES_PORT_5432_TCP_PORT" -U postgres'''
+kafka-avro-console-consumer:
+  image: confluent/tools
+  links:
+    - zookeeper
+    - kafka
+    - schema-registry
+  entrypoint: ['/confluent-tools.sh', 'kafka-avro-console-consumer']
 kafka-tools:
   image: confluent/tools
   links:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,6 @@ zookeeper:
   hostname: zookeeper
   ports:
     - '42181:2181'
-    - '42888:2888'
-    - '43888:3888'
 kafka:
   image: confluent/kafka
   hostname: kafka

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,12 +25,12 @@ schema-registry:
   environment:
     SCHEMA_REGISTRY_AVRO_COMPATIBILITY_LEVEL: none
 postgres:
-  image: confluent/postgres-bw:0.1
+  image: local-postgres-bw:dev
   hostname: postgres
   ports:
     - '45432:5432'
 bottledwater:
-  image: confluent/bottledwater:0.1
+  image: local-bottledwater:dev
   hostname: bottledwater
   links:
     - postgres


### PR DESCRIPTION
This moves some of the configuration needed to start up a Bottled Water dev setup out of documentation and into automation, in the form of a `docker-compose.yml`.  In particular links between containers and common command-line arguments can be stored there instead of typed each time.

This PR is similar to (and partly influenced by) PR #25 by @tkaemming, although I made some changes to accommodate the recently merged JSON support (#45), to make it easier to interact with the components of the test cluster from the host machine (e.g. write to Postgres, read from Kafka), and to use locally built Docker images for Bottled Water itself.  To quote PR #25:

> This makes it a bit easier to start and stop (and destroy) the linked containers for the test environment, and makes the user-defined flags such as `--topic` a bit more obvious, since they're not alongside the networking topology flags like `--link`.

As well as spiritual inspiration for the `docker-compose.yml`, this also explicitly reuses the README changes from #25 (thanks @tkaemming!).