### PR TITLE
Robustify Docker build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,8 @@ tmp/%: build/% tmp
 docker-build:
 	docker build -f build/Dockerfile.build -t bwbuild:$(DOCKER_TAG) .
 
-docker-client: tmp/Dockerfile.client tmp/avro-1.8.0.tar.gz tmp/librdkafka-0.9.0.tar.gz tmp/bottledwater-bin.tar.gz tmp/bottledwater-docker-wrapper.sh
+docker-client: tmp/Dockerfile.client tmp/avro.tar.gz tmp/librdkafka.tar.gz tmp/bottledwater-bin.tar.gz tmp/bottledwater-docker-wrapper.sh
 	docker build -f $< -t local-bottledwater:$(DOCKER_TAG) tmp
 
-docker-postgres: tmp/Dockerfile.postgres tmp/bottledwater-ext.tar.gz tmp/avro-1.8.0.tar.gz tmp/replication-config.sh
+docker-postgres: tmp/Dockerfile.postgres tmp/bottledwater-ext.tar.gz tmp/avro.tar.gz tmp/replication-config.sh
 	docker build -f $< -t local-postgres-bw:$(DOCKER_TAG) tmp

--- a/build/Dockerfile.build
+++ b/build/Dockerfile.build
@@ -18,8 +18,9 @@ RUN apt-get update && \
     # Docker image includes libpq5 version 9.5.x, which we are not yet
     # compatible with, even though the Postgres version (and $PG_VERSION) are
     # 9.4.x.
-    apt-get install -y --force-yes \
+    apt-get install -y --no-install-recommends --force-yes \
         build-essential \
+        ca-certificates \
         cmake \
         curl \
         libcurl4-openssl-dev \

--- a/build/Dockerfile.build
+++ b/build/Dockerfile.build
@@ -13,11 +13,11 @@
 FROM postgres:9.4
 
 RUN apt-get update && \
-    # --force-yes is needed because we are downgrading libpq5 to $PG_VERSION
+    # --force-yes is needed because we are downgrading libpq5 to $PG_MAJOR
     # (set by the postgres:9.4 Docker image).  Confusingly the postgres:9.4
     # Docker image includes libpq5 version 9.5.x, which we are not yet
-    # compatible with, even though the Postgres version (and $PG_VERSION) are
-    # 9.4.x.
+    # compatible with, even though the Postgres version (and
+    # $PG_MAJOR/$PG_VERSION) are 9.4.x.
     apt-get install -y --no-install-recommends --force-yes \
         build-essential \
         ca-certificates \
@@ -25,10 +25,10 @@ RUN apt-get update && \
         curl \
         libcurl4-openssl-dev \
         libjansson-dev \
-        libpq5=${PG_VERSION} \
-        libpq-dev=${PG_VERSION} \
+        libpq5=${PG_MAJOR}\* \
+        libpq-dev=${PG_MAJOR}\* \
         pkg-config \
-        postgresql-server-dev-9.4=${PG_VERSION}
+        postgresql-server-dev-${PG_MAJOR}=${PG_MAJOR}\*
 
 # Avro
 RUN curl -o /root/avro-c-1.8.0.tar.gz -SL http://archive.apache.org/dist/avro/avro-1.8.0/c/avro-c-1.8.0.tar.gz && \
@@ -50,6 +50,6 @@ RUN curl -o /root/librdkafka-0.9.0.tar.gz -SL https://github.com/edenhill/librdk
 COPY . /root/bottledwater
 RUN cd /root/bottledwater && \
     make clean && make && make install && cd / && \
-    tar czf bottledwater-ext.tar.gz usr/lib/postgresql/9.4/lib/bottledwater.so usr/share/postgresql/9.4/extension/bottledwater* && \
+    tar czf bottledwater-ext.tar.gz usr/lib/postgresql/${PG_MAJOR}/lib/bottledwater.so usr/share/postgresql/${PG_MAJOR}/extension/bottledwater* && \
     cp /root/bottledwater/kafka/bottledwater /root/bottledwater/client/bwtest /usr/local/bin && \
     tar czf bottledwater-bin.tar.gz usr/local/bin/bottledwater usr/local/bin/bwtest

--- a/build/Dockerfile.build
+++ b/build/Dockerfile.build
@@ -12,6 +12,10 @@
 
 FROM postgres:9.4
 
+ENV RDKAFKA_VERSION=0.9.0 \
+    AVRO_C_VERSION=1.8.0 \
+    AVRO_C_SHASUM="af7757633ccf067b1f140c58161e2cdc2f2f003d  /root/avro-c-1.8.0.tar.gz"
+
 RUN apt-get update && \
     # --force-yes is needed because we are downgrading libpq5 to $PG_MAJOR
     # (set by the postgres:9.4 Docker image).  Confusingly the postgres:9.4
@@ -31,20 +35,20 @@ RUN apt-get update && \
         postgresql-server-dev-${PG_MAJOR}=${PG_MAJOR}\*
 
 # Avro
-RUN curl -o /root/avro-c-1.8.0.tar.gz -SL http://archive.apache.org/dist/avro/avro-1.8.0/c/avro-c-1.8.0.tar.gz && \
-    echo 'af7757633ccf067b1f140c58161e2cdc2f2f003d  /root/avro-c-1.8.0.tar.gz' | shasum -a 1 -b -c && \
-    tar -xzf /root/avro-c-1.8.0.tar.gz -C /root && \
-    mkdir /root/avro-c-1.8.0/build && \
-    cd /root/avro-c-1.8.0/build && \
+RUN curl -o /root/avro-c-${AVRO_C_VERSION}.tar.gz -SL http://archive.apache.org/dist/avro/avro-${AVRO_C_VERSION}/c/avro-c-${AVRO_C_VERSION}.tar.gz && \
+    echo "${AVRO_C_SHASUM}" | shasum -a 1 -b -c && \
+    tar -xzf /root/avro-c-${AVRO_C_VERSION}.tar.gz -C /root && \
+    mkdir /root/avro-c-${AVRO_C_VERSION}/build && \
+    cd /root/avro-c-${AVRO_C_VERSION}/build && \
     cmake .. -DCMAKE_INSTALL_PREFIX=/usr/local -DCMAKE_BUILD_TYPE=RelWithDebInfo && \
     make && make test && make install && cd / && \
-    tar czf avro-1.8.0.tar.gz usr/local/include/avro usr/local/lib/libavro* usr/local/lib/pkgconfig/avro-c.pc
+    tar czf avro.tar.gz usr/local/include/avro usr/local/lib/libavro* usr/local/lib/pkgconfig/avro-c.pc
 
 # librdkafka
-RUN curl -o /root/librdkafka-0.9.0.tar.gz -SL https://github.com/edenhill/librdkafka/archive/v0.9.0.tar.gz && \
-    tar -xzf /root/librdkafka-0.9.0.tar.gz -C /root && \
-    cd /root/librdkafka-0.9.0 && ./configure && make && make install && cd / && \
-    tar czf librdkafka-0.9.0.tar.gz usr/local/include/librdkafka usr/local/lib/librdkafka*
+RUN curl -o /root/librdkafka-${RDKAFKA_VERSION}.tar.gz -SL https://github.com/edenhill/librdkafka/archive/v${RDKAFKA_VERSION}.tar.gz && \
+    tar -xzf /root/librdkafka-${RDKAFKA_VERSION}.tar.gz -C /root && \
+    cd /root/librdkafka-${RDKAFKA_VERSION} && ./configure && make && make install && cd / && \
+    tar czf librdkafka.tar.gz usr/local/include/librdkafka usr/local/lib/librdkafka*
 
 # Bottled Water
 COPY . /root/bottledwater

--- a/build/Dockerfile.client
+++ b/build/Dockerfile.client
@@ -15,15 +15,15 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         libcurl3 libjansson4 libpq5
 
-ADD avro-1.8.0.tar.gz /
-ADD librdkafka-0.9.0.tar.gz /
+ADD avro.tar.gz /
+ADD librdkafka.tar.gz /
 ADD bottledwater-bin.tar.gz /
 
 COPY bottledwater-docker-wrapper.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/bottledwater-docker-wrapper.sh
 
-RUN cp /usr/local/lib/librdkafka.so.1 /usr/lib/x86_64-linux-gnu && \
-    cp /usr/local/lib/libavro.so.23.0.0 /usr/lib/x86_64-linux-gnu
+RUN cp /usr/local/lib/librdkafka.so.* /usr/lib/x86_64-linux-gnu && \
+    cp /usr/local/lib/libavro.so.* /usr/lib/x86_64-linux-gnu
 
 ENTRYPOINT ["/usr/local/bin/bottledwater-docker-wrapper.sh"]
 CMD ["--output-format=json", "--allow-unkeyed"]

--- a/build/Dockerfile.client
+++ b/build/Dockerfile.client
@@ -12,7 +12,8 @@ FROM postgres:9.4
 
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y libcurl3 libjansson4 libpq5
+    apt-get install -y --no-install-recommends \
+        libcurl3 libjansson4 libpq5
 
 ADD avro-1.8.0.tar.gz /
 ADD librdkafka-0.9.0.tar.gz /

--- a/build/Dockerfile.postgres
+++ b/build/Dockerfile.postgres
@@ -24,6 +24,6 @@ RUN apt-get update && \
     apt-get install -y libjansson4
 
 ADD bottledwater-ext.tar.gz /
-ADD avro-1.8.0.tar.gz /
-RUN cp /usr/local/lib/libavro.so.23.0.0 /usr/lib/x86_64-linux-gnu/libavro.so.23.0.0
+ADD avro.tar.gz /
+RUN cp /usr/local/lib/libavro.so.* /usr/lib/x86_64-linux-gnu/
 COPY replication-config.sh /docker-entrypoint-initdb.d/replication-config.sh


### PR DESCRIPTION
This PR has a few changes extracted from #55 (by @scordeiro) to fix the current Docker build (which has been broken by some changes in the `postgres:9.4` upstream image), and make the build more robust to similar changes in the future.  It also makes it easier to change the versions of the avro-c and rdkafka libraries we depend on.