### PR TITLE
"flush" wal_pos reported in keepalive unless we have pending transactions

### DIFF
--- a/client/protocol_client.c
+++ b/client/protocol_client.c
@@ -377,3 +377,16 @@ int read_entirely(avro_value_t *value, avro_reader_t reader, const void *buf, si
 
     return err;
 }
+
+
+/* Return: 0 if we should acknowledge wal_pos as flushed;
+ *         FRAME_READER_SYNC_PENDING if we should not because we have
+ *         transactions pending sync;
+ *         anything else to signify an error. */
+int handle_keepalive(frame_reader_t reader, uint64_t wal_pos) {
+    if (reader->on_keepalive) {
+        int err = 0;
+        check(err, reader->on_keepalive(reader->cb_context, wal_pos));
+    }
+    return 0;
+}


### PR DESCRIPTION
The server may generate WAL that doesn't correspond to a transaction commit, e.g.:

 * automatic checkpoints driven by [checkpoint_timeout](http://www.postgresql.org/docs/current/static/runtime-config-wal.html#GUC-CHECKPOINT-TIMEOUT)
 * transactions that roll back

Currently we only update our "flush lsn" when we see a COMMIT, so if enough of this non-committed-transaction activity occurs before we see a COMMIT, the server may run out of WAL space and crash.  I believe this is the root cause of #68.

The server's regular keepalive messages are already informing us of the updated wal_pos resulting from this activity.  So this commit makes us acknowledge it as "flushed" (even though we didn't actually do anything about it), provided that we aren't currently waiting for Kafka to acknowledge a transaction in flight (in which case acknowledging the subsequent activity would could result in us losing the transaction in flight, in case of a restart).

I believe this design is sound, but I'm not yet 100% sure this is the right implementation.  In particular, right now this triggers the ["Commits not in WAL order!" warning](https://github.com/confluentinc/bottledwater-pg/blob/master/kafka/bottledwater.c#L505) the first time an actual COMMIT comes in.  I think that is actually due to a (harmless) bug - we do a redundant extra checkpoint of transaction 0 (aka the snapshot) - but I'm not sure yet.  In any case I was hoping to get some eyes on this - @ept if you have any spare time your thoughts would be much appreciated :)