### PR TITLE
"flush" wal_pos reported in keepalive unless we have pending transactions

### DIFF
--- a/client/protocol_client.c
+++ b/client/protocol_client.c
@@ -377,3 +377,16 @@ int read_entirely(avro_value_t *value, avro_reader_t reader, const void *buf, si
 
     return err;
 }
+
+
+/* Return: 0 if we should acknowledge wal_pos as flushed;
+ *         FRAME_READER_SYNC_PENDING if we should not because we have
+ *         transactions pending sync;
+ *         anything else to signify an error. */
+int handle_keepalive(frame_reader_t reader, uint64_t wal_pos) {
+    if (reader->on_keepalive) {
+        int err = 0;
+        check(err, reader->on_keepalive(reader->cb_context, wal_pos));
+    }
+    return 0;
+}

--- a/kafka/bottledwater.c
+++ b/kafka/bottledwater.c
@@ -322,7 +322,12 @@ static int on_begin_txn(void *_context, uint64_t wal_pos, uint32_t xid) {
 
     // If the circular buffer is full, we have to block and wait for some transactions
     // to be delivered to Kafka and acknowledged for the broker.
-    while (xact_list_full(context)) backpressure(context);
+    while (xact_list_full(context)) {
+#ifdef DEBUG
+        fprintf(stderr, "Too many transactions in flight, applying backpressure\n");
+#endif
+        backpressure(context);
+    }
 
     context->xact_head = (context->xact_head + 1) % XACT_LIST_LEN;
     transaction_info *xact = &context->xact_list[context->xact_head];
@@ -468,6 +473,9 @@ int send_kafka_msg(producer_context_t context, uint64_t wal_pos, Oid relid,
         // If data from Postgres is coming in faster than we can send it on to Kafka, we
         // create backpressure by blocking until the producer's queue has drained a bit.
         if (rd_kafka_errno2err(errno) == RD_KAFKA_RESP_ERR__QUEUE_FULL) {
+#ifdef DEBUG
+            fprintf(stderr, "Kafka producer queue is full, applying backpressure\n");
+#endif
             backpressure(context);
 
         } else if (err != 0) {

--- a/kafka/bottledwater.c
+++ b/kafka/bottledwater.c
@@ -117,6 +117,7 @@ static int on_update_row(void *_context, uint64_t wal_pos, Oid relid,
 static int on_delete_row(void *_context, uint64_t wal_pos, Oid relid,
         const void *key_bin, size_t key_len, avro_value_t *key_val,
         const void *old_bin, size_t old_len, avro_value_t *old_val);
+static int on_keepalive(void *_context, uint64_t wal_pos);
 int send_kafka_msg(producer_context_t context, uint64_t wal_pos, Oid relid,
         const void *key_bin, size_t key_len,
         const void *val_bin, size_t val_len);
@@ -402,6 +403,16 @@ static int on_delete_row(void *_context, uint64_t wal_pos, Oid relid,
         return 0; // delete on unkeyed table --> can't do anything
 }
 
+static int on_keepalive(void *_context, uint64_t wal_pos) {
+    producer_context_t context = (producer_context_t) _context;
+
+    if (xact_list_empty(context)) {
+        return 0;
+    } else {
+        return FRAME_READER_SYNC_PENDING;
+    }
+}
+
 
 int send_kafka_msg(producer_context_t context, uint64_t wal_pos, Oid relid,
         const void *key_bin, size_t key_len,
@@ -587,6 +598,7 @@ client_context_t init_client() {
     frame_reader->on_insert_row   = on_insert_row;
     frame_reader->on_update_row   = on_update_row;
     frame_reader->on_delete_row   = on_delete_row;
+    frame_reader->on_keepalive    = on_keepalive;
 
     client_context_t client = db_client_new();
     client->app_name = APP_NAME;


### PR DESCRIPTION
The server may generate WAL that doesn't correspond to a transaction commit, e.g.:

 * automatic checkpoints driven by [checkpoint_timeout](http://www.postgresql.org/docs/current/static/runtime-config-wal.html#GUC-CHECKPOINT-TIMEOUT)
 * transactions that roll back

Currently we only update our "flush lsn" when we see a COMMIT, so if enough of this non-committed-transaction activity occurs before we see a COMMIT, the server may run out of WAL space and crash.  I believe this is the root cause of #68.

The server's regular keepalive messages are already informing us of the updated wal_pos resulting from this activity.  So this commit makes us acknowledge it as "flushed" (even though we didn't actually do anything about it), provided that we aren't currently waiting for Kafka to acknowledge a transaction in flight (in which case acknowledging the subsequent activity would could result in us losing the transaction in flight, in case of a restart).

I've also tested the case where Bottled Water restarts before the transaction is committed, and it does pick up from the right point and capture the whole transaction.

In the process of debugging this I ran into a bug in the client's logic for keeping track of transactions in flight, where the client would acknowledge each commit twice (each time it processed a new COMMIT, it would first reprocess the COMMIT of the previous transaction).  I think the bug was harmless, but it made the logic hard to reason about, since effectively it was processing records since "removed" from the circular buffer abstraction.  Since this change allows keepalives during that interval to update the `fsync_lsn`, it would also trigger the ["Commits not in WAL order!" warning](https://github.com/confluentinc/bottledwater-pg/blob/83f75b787af569d3ed92e1343eaa51efd6c319e5/kafka/bottledwater.c#L505) each time a transaction came in.

To work around that, I also refactored the circular buffer of transactions to remove some special cases in the handling of the initial snapshot transaction and distinguish more clearly between the buffer being empty and full.

I initially planned to write automated tests for this behaviour by querying `pg_replication_slots.restart_lsn`; however, the very async nature of the communication made it difficult to make the tests pass without large (20 second) `sleep`s - Bottled Water only checkpoints every 10 seconds, Postgres only issues keepalives once per `checkpoint_timeout`, etc.  So right now there is no additional test coverage.  It passes the existing tests, though :)