### PR TITLE
Support `--on-error=log`

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,44 @@ again and running:
     select pg_drop_replication_slot('bottledwater');
 
 
+### Error handling
+
+If Bottled Water encounters an error - such as failure to communicate with Kafka or
+the Schema Registry - its default behaviour is for the client to exit, halting the
+flow of data into Kafka.  This may seem like an odd default, but since Postgres will
+retain and replay the logical replication stream until Bottled Water acknowledges it,
+it ensures that:
+
+ * it will never miss an update (every update made in Postgres will eventually be
+   written to Kafka) - _provided_ that whatever caused the error is resolved
+   externally (e.g.  restoring connectivity to Kafka) and the Bottled Water client is
+   then restarted;
+
+ * it will never write corrupted data to Kafka: e.g. if unable to obtain a schema id
+   from the Schema Registry for the current update, rather than writing to Kafka
+   without a schema id (which would leave consumers unable to parse the update), it
+   will wait until the problem is resolved.
+
+However, in some scenarios, exiting on the first error may not be desirable:
+
+ * if there is an error publishing for one table (e.g. if Kafka is configured not to
+   autocreate topics and the corresponding topic has not been explicitly created), you
+   may not want to halt updates for all other tables.
+
+ * if the reason for the error cannot be resolved quickly (e.g. Kafka misconfiguration
+   or prolonged outage), Bottled Water may threaten the stability of the Postgres
+   server.  This is because Postgres will store WAL on disk for all updates made since
+   Bottled Water last acknowledged (i.e. successfully published) an update.  If
+   Postgres has a high write throughput, Bottled Water being unavailable may cause the
+   disk on the Postgres server to fill up, likely causing Postgres to crash.
+
+To support these scenarios, Bottled Water supports an alternative error handling
+policy where it will simply log that the error occurred and drop the update it was
+attempting to process, acknowledging the update so that Postgres can stop retaining
+WAL.  This policy can be enabled via the `--on-error` command-line switch.  N.B. that
+in this mode Bottled Water can no longer guarantee to never miss an update.
+
+
 Consuming data
 --------------
 

--- a/build/bottledwater-docker-wrapper.sh
+++ b/build/bottledwater-docker-wrapper.sh
@@ -1,19 +1,42 @@
-#!/bin/sh
+#!/usr/bin/env bash
+
+log() { echo "$0: $@" >&2; }
+
+declare -a bw_opts
 
 POSTGRES_CONNECTION_STRING="hostaddr=$POSTGRES_PORT_5432_TCP_ADDR port=$POSTGRES_PORT_5432_TCP_PORT dbname=postgres user=postgres"
 KAFKA_BROKER="$KAFKA_PORT_9092_TCP_ADDR:$KAFKA_PORT_9092_TCP_PORT"
+bw_opts+=(--postgres="$POSTGRES_CONNECTION_STRING" --broker="$KAFKA_BROKER")
+
+for var in "${!BOTTLED_WATER_@}"; do
+  option=$(sed 's/^BOTTLED_WATER_//' <<<"$var" | tr '[:upper:]_' '[:lower:]-')
+  value=${!var}
+  case $(tr '[:upper:]' '[:lower:]' <<<"$value") in
+    "")
+      # Probably set by docker-compose env passthrough, ignore
+      ;;
+    true | yes | y | 1)
+      # boolean options don't admit arguments
+      log "Setting option --$option"
+      bw_opts+=(--"$option")
+      ;;
+    false | no | n | 0)
+      log "WARNING: Ignoring environment variable $var=$value, no support for explicitly negating option --$option"
+      ;;
+    *)
+      log "Setting option --$option=$value"
+      bw_opts+=(--"$option"="$value")
+      ;;
+  esac
+done
 
 if [ -n "$SCHEMA_REGISTRY_PORT_8081_TCP_ADDR" ]; then
   SCHEMA_REGISTRY_URL="http://${SCHEMA_REGISTRY_PORT_8081_TCP_ADDR}:${SCHEMA_REGISTRY_PORT_8081_TCP_PORT}"
 
-  schema_registry_opts="--schema-registry=$SCHEMA_REGISTRY_URL"
-else
-  schema_registry_opts=
+  log "Detected schema registry, setting --schema-registry=$SCHEMA_REGISTRY_URL"
+  bw_opts+=(--schema-registry="$SCHEMA_REGISTRY_URL")
 fi
 
-exec /usr/local/bin/bottledwater \
-    --postgres="$POSTGRES_CONNECTION_STRING" \
-    --broker="$KAFKA_BROKER" \
-    $schema_registry_opts \
-    "$@"
-
+BOTTLEDWATER=/usr/local/bin/bottledwater
+log "Running: $BOTTLEDWATER ${bw_opts[@]} $@"
+exec "$BOTTLEDWATER" "${bw_opts[@]}" "$@"

--- a/client/connect.c
+++ b/client/connect.c
@@ -387,7 +387,7 @@ int snapshot_tuple(client_context_t context, PGresult *res, int row_number) {
     int err = parse_frame(context->repl.frame_reader, 0, PQgetvalue(res, row_number, 0),
             PQgetlength(res, row_number, 0));
     if (err) {
-        client_error(context, "Error parsing frame data: %s", avro_strerror());
+        client_error(context, "Error parsing frame data: %s", context->repl.frame_reader->error);
     }
     return err;
 }

--- a/client/protocol_client.c
+++ b/client/protocol_client.c
@@ -2,10 +2,21 @@
  * and the client application. */
 
 #include "protocol_client.h"
+#include <stdarg.h>
 #include <stdlib.h>
 #include <string.h>
 
 #define check(err, call) { err = call; if (err) return err; }
+
+#define check_handle(err, reader, call, fmt, ...) \
+    do { \
+        err = call; \
+        if (err) { \
+            return frame_reader_handle(reader, err, fmt, ##__VA_ARGS__); \
+        } \
+    } while (0)
+
+#define check_avro(err, reader, call) { check_handle(err, reader, call, "Avro error: %s", avro_strerror()); }
 
 #define check_alloc(x) \
     do { \
@@ -27,12 +38,14 @@ schema_list_entry *schema_list_lookup(frame_reader_t reader, int64_t relid);
 schema_list_entry *schema_list_replace(frame_reader_t reader, int64_t relid);
 schema_list_entry *schema_list_entry_new(frame_reader_t reader);
 void schema_list_entry_decrefs(schema_list_entry *entry);
-int read_entirely(avro_value_t *value, avro_reader_t reader, const void *buf, size_t len);
+int read_entirely(frame_reader_t reader, avro_value_t *value, avro_reader_t avro_reader, const void *buf, size_t len);
+
+int frame_reader_handle(frame_reader_t reader, int err, const char *fmt, ...) __attribute__ ((format (printf, 3, 4)));
 
 
 int parse_frame(frame_reader_t reader, uint64_t wal_pos, char *buf, int buflen) {
     int err = 0;
-    check(err, read_entirely(&reader->frame_value, reader->avro_reader, buf, buflen));
+    check(err, read_entirely(reader, &reader->frame_value, reader->avro_reader, buf, buflen));
     check(err, process_frame(&reader->frame_value, reader, wal_pos));
     return err;
 }
@@ -43,13 +56,13 @@ int process_frame(avro_value_t *frame_val, frame_reader_t reader, uint64_t wal_p
     size_t num_messages;
     avro_value_t msg_val, union_val, record_val;
 
-    check(err, avro_value_get_by_index(frame_val, 0, &msg_val, NULL));
-    check(err, avro_value_get_size(&msg_val, &num_messages));
+    check_avro(err, reader, avro_value_get_by_index(frame_val, 0, &msg_val, NULL));
+    check_avro(err, reader, avro_value_get_size(&msg_val, &num_messages));
 
     for (int i = 0; i < num_messages; i++) {
-        check(err, avro_value_get_by_index(&msg_val, i, &union_val, NULL));
-        check(err, avro_value_get_discriminant(&union_val, &msg_type));
-        check(err, avro_value_get_current_branch(&union_val, &record_val));
+        check_avro(err, reader, avro_value_get_by_index(&msg_val, i, &union_val, NULL));
+        check_avro(err, reader, avro_value_get_discriminant(&union_val, &msg_type));
+        check_avro(err, reader, avro_value_get_current_branch(&union_val, &record_val));
 
         switch (msg_type) {
             case PROTOCOL_MSG_BEGIN_TXN:
@@ -71,8 +84,8 @@ int process_frame(avro_value_t *frame_val, frame_reader_t reader, uint64_t wal_p
                 check(err, process_frame_delete(&record_val, reader, wal_pos));
                 break;
             default:
-                avro_set_error("Unknown message type %d", msg_type);
-                return EINVAL;
+                return frame_reader_handle(reader, EINVAL,
+                        "Unknown message type %d", msg_type);
         }
     }
     return err;
@@ -83,11 +96,12 @@ int process_frame_begin_txn(avro_value_t *record_val, frame_reader_t reader, uin
     avro_value_t xid_val;
     int64_t xid;
 
-    check(err, avro_value_get_by_index(record_val, 0, &xid_val, NULL));
-    check(err, avro_value_get_long(&xid_val, &xid));
+    check_avro(err, reader, avro_value_get_by_index(record_val, 0, &xid_val, NULL));
+    check_avro(err, reader, avro_value_get_long(&xid_val, &xid));
 
     if (reader->on_begin_txn) {
-        check(err, reader->on_begin_txn(reader->cb_context, wal_pos, (uint32_t) xid));
+        check_handle(err, reader, reader->on_begin_txn(reader->cb_context, wal_pos, (uint32_t) xid),
+                "error in begin_txn callback for xid %" PRIu64, xid);
     }
     return err;
 }
@@ -97,11 +111,12 @@ int process_frame_commit_txn(avro_value_t *record_val, frame_reader_t reader, ui
     avro_value_t xid_val;
     int64_t xid;
 
-    check(err, avro_value_get_by_index(record_val, 0, &xid_val, NULL));
-    check(err, avro_value_get_long(&xid_val, &xid));
+    check_avro(err, reader, avro_value_get_by_index(record_val, 0, &xid_val, NULL));
+    check_avro(err, reader, avro_value_get_long(&xid_val, &xid));
 
     if (reader->on_commit_txn) {
-        check(err, reader->on_commit_txn(reader->cb_context, wal_pos, (uint32_t) xid));
+        check_handle(err, reader, reader->on_commit_txn(reader->cb_context, wal_pos, (uint32_t) xid),
+                "error in commit_txn callback for xid %" PRIu64, xid);
     }
     return err;
 }
@@ -114,13 +129,13 @@ int process_frame_table_schema(avro_value_t *record_val, frame_reader_t reader, 
     size_t key_schema_len = 1, row_schema_len;
     avro_schema_t key_schema = NULL, row_schema;
 
-    check(err, avro_value_get_by_index(record_val, 0, &relid_val,      NULL));
-    check(err, avro_value_get_by_index(record_val, 1, &key_schema_val, NULL));
-    check(err, avro_value_get_by_index(record_val, 2, &row_schema_val, NULL));
-    check(err, avro_value_get_long(&relid_val, &relid));
-    check(err, avro_value_get_discriminant(&key_schema_val, &key_schema_present));
-    check(err, avro_value_get_string(&row_schema_val, &row_schema_json, &row_schema_len));
-    check(err, avro_schema_from_json_length(row_schema_json, row_schema_len - 1, &row_schema));
+    check_avro(err, reader, avro_value_get_by_index(record_val, 0, &relid_val,      NULL));
+    check_avro(err, reader, avro_value_get_by_index(record_val, 1, &key_schema_val, NULL));
+    check_avro(err, reader, avro_value_get_by_index(record_val, 2, &row_schema_val, NULL));
+    check_avro(err, reader, avro_value_get_long(&relid_val, &relid));
+    check_avro(err, reader, avro_value_get_discriminant(&key_schema_val, &key_schema_present));
+    check_avro(err, reader, avro_value_get_string(&row_schema_val, &row_schema_json, &row_schema_len));
+    check_avro(err, reader, avro_schema_from_json_length(row_schema_json, row_schema_len - 1, &row_schema));
 
     schema_list_entry *entry = schema_list_replace(reader, relid);
     entry->relid = relid;
@@ -131,9 +146,9 @@ int process_frame_table_schema(avro_value_t *record_val, frame_reader_t reader, 
     entry->avro_reader = avro_reader_memory(NULL, 0);
 
     if (key_schema_present) {
-        check(err, avro_value_get_current_branch(&key_schema_val, &branch_val));
-        check(err, avro_value_get_string(&branch_val, &key_schema_json, &key_schema_len));
-        check(err, avro_schema_from_json_length(key_schema_json, key_schema_len - 1, &key_schema));
+        check_avro(err, reader, avro_value_get_current_branch(&key_schema_val, &branch_val));
+        check_avro(err, reader, avro_value_get_string(&branch_val, &key_schema_json, &key_schema_len));
+        check_avro(err, reader, avro_schema_from_json_length(key_schema_json, key_schema_len - 1, &key_schema));
         entry->key_schema = key_schema;
         entry->key_iface = avro_generic_class_from_schema(key_schema);
         avro_generic_value_new(entry->key_iface, &entry->key_value);
@@ -142,9 +157,11 @@ int process_frame_table_schema(avro_value_t *record_val, frame_reader_t reader, 
     }
 
     if (reader->on_table_schema) {
-        check(err, reader->on_table_schema(reader->cb_context, wal_pos, relid,
+        check_handle(err, reader,
+                reader->on_table_schema(reader->cb_context, wal_pos, relid,
                     key_schema_json, key_schema_len - 1, key_schema,
-                    row_schema_json, row_schema_len - 1, row_schema));
+                    row_schema_json, row_schema_len - 1, row_schema),
+                "error in table_schema callback for relid %" PRIu64, relid);
     }
     return err;
 }
@@ -156,31 +173,33 @@ int process_frame_insert(avro_value_t *record_val, frame_reader_t reader, uint64
     const void *key_bin = NULL, *new_bin = NULL;
     size_t key_len = 0, new_len = 0;
 
-    check(err, avro_value_get_by_index(record_val, 0, &relid_val, NULL));
-    check(err, avro_value_get_by_index(record_val, 1, &key_val,   NULL));
-    check(err, avro_value_get_by_index(record_val, 2, &new_val,   NULL));
-    check(err, avro_value_get_long(&relid_val, &relid));
-    check(err, avro_value_get_discriminant(&key_val, &key_present));
-    check(err, avro_value_get_bytes(&new_val, &new_bin, &new_len));
+    check_avro(err, reader, avro_value_get_by_index(record_val, 0, &relid_val, NULL));
+    check_avro(err, reader, avro_value_get_by_index(record_val, 1, &key_val,   NULL));
+    check_avro(err, reader, avro_value_get_by_index(record_val, 2, &new_val,   NULL));
+    check_avro(err, reader, avro_value_get_long(&relid_val, &relid));
+    check_avro(err, reader, avro_value_get_discriminant(&key_val, &key_present));
+    check_avro(err, reader, avro_value_get_bytes(&new_val, &new_bin, &new_len));
 
     schema_list_entry *entry = schema_list_lookup(reader, relid);
     if (!entry) {
-        avro_set_error("Received insert for unknown relid %u", relid);
-        return EINVAL;
+        return frame_reader_handle(reader, EINVAL,
+                "Received insert for unknown relid %" PRIu64, relid);
     }
 
     if (key_present) {
-        check(err, avro_value_get_current_branch(&key_val, &branch_val));
-        check(err, avro_value_get_bytes(&branch_val, &key_bin, &key_len));
-        check(err, read_entirely(&entry->key_value, entry->avro_reader, key_bin, key_len));
+        check_avro(err, reader, avro_value_get_current_branch(&key_val, &branch_val));
+        check_avro(err, reader, avro_value_get_bytes(&branch_val, &key_bin, &key_len));
+        check(err, read_entirely(reader, &entry->key_value, entry->avro_reader, key_bin, key_len));
     }
 
-    check(err, read_entirely(&entry->row_value, entry->avro_reader, new_bin, new_len));
+    check(err, read_entirely(reader, &entry->row_value, entry->avro_reader, new_bin, new_len));
 
     if (reader->on_insert_row) {
-        check(err, reader->on_insert_row(reader->cb_context, wal_pos, relid,
+        check_handle(err, reader,
+                reader->on_insert_row(reader->cb_context, wal_pos, relid,
                     key_bin, key_len, key_bin ? &entry->key_value : NULL,
-                    new_bin, new_len, &entry->row_value));
+                    new_bin, new_len, &entry->row_value),
+                "error in insert_row callback for relid %" PRIu64, relid);
     }
     return err;
 }
@@ -192,40 +211,42 @@ int process_frame_update(avro_value_t *record_val, frame_reader_t reader, uint64
     const void *key_bin = NULL, *old_bin = NULL, *new_bin = NULL;
     size_t key_len = 0, old_len = 0, new_len = 0;
 
-    check(err, avro_value_get_by_index(record_val, 0, &relid_val, NULL));
-    check(err, avro_value_get_by_index(record_val, 1, &key_val,   NULL));
-    check(err, avro_value_get_by_index(record_val, 2, &old_val,   NULL));
-    check(err, avro_value_get_by_index(record_val, 3, &new_val,   NULL));
-    check(err, avro_value_get_long(&relid_val, &relid));
-    check(err, avro_value_get_discriminant(&key_val, &key_present));
-    check(err, avro_value_get_discriminant(&old_val, &old_present));
-    check(err, avro_value_get_bytes(&new_val, &new_bin, &new_len));
+    check_avro(err, reader, avro_value_get_by_index(record_val, 0, &relid_val, NULL));
+    check_avro(err, reader, avro_value_get_by_index(record_val, 1, &key_val,   NULL));
+    check_avro(err, reader, avro_value_get_by_index(record_val, 2, &old_val,   NULL));
+    check_avro(err, reader, avro_value_get_by_index(record_val, 3, &new_val,   NULL));
+    check_avro(err, reader, avro_value_get_long(&relid_val, &relid));
+    check_avro(err, reader, avro_value_get_discriminant(&key_val, &key_present));
+    check_avro(err, reader, avro_value_get_discriminant(&old_val, &old_present));
+    check_avro(err, reader, avro_value_get_bytes(&new_val, &new_bin, &new_len));
 
     schema_list_entry *entry = schema_list_lookup(reader, relid);
     if (!entry) {
-        avro_set_error("Received update for unknown relid %u", relid);
-        return EINVAL;
+        return frame_reader_handle(reader, EINVAL,
+                "Received update for unknown relid %" PRIu64, relid);
     }
 
     if (key_present) {
-        check(err, avro_value_get_current_branch(&key_val, &branch_val));
-        check(err, avro_value_get_bytes(&branch_val, &key_bin, &key_len));
-        check(err, read_entirely(&entry->key_value, entry->avro_reader, key_bin, key_len));
+        check_avro(err, reader, avro_value_get_current_branch(&key_val, &branch_val));
+        check_avro(err, reader, avro_value_get_bytes(&branch_val, &key_bin, &key_len));
+        check(err, read_entirely(reader, &entry->key_value, entry->avro_reader, key_bin, key_len));
     }
 
     if (old_present) {
-        check(err, avro_value_get_current_branch(&old_val, &branch_val));
-        check(err, avro_value_get_bytes(&branch_val, &old_bin, &old_len));
-        check(err, read_entirely(&entry->old_value, entry->avro_reader, old_bin, old_len));
+        check_avro(err, reader, avro_value_get_current_branch(&old_val, &branch_val));
+        check_avro(err, reader, avro_value_get_bytes(&branch_val, &old_bin, &old_len));
+        check(err, read_entirely(reader, &entry->old_value, entry->avro_reader, old_bin, old_len));
     }
 
-    check(err, read_entirely(&entry->row_value, entry->avro_reader, new_bin, new_len));
+    check(err, read_entirely(reader, &entry->row_value, entry->avro_reader, new_bin, new_len));
 
     if (reader->on_update_row) {
-        check(err, reader->on_update_row(reader->cb_context, wal_pos, relid,
+        check_handle(err, reader,
+                reader->on_update_row(reader->cb_context, wal_pos, relid,
                     key_bin, key_len, key_bin ? &entry->key_value : NULL,
                     old_bin, old_len, old_bin ? &entry->old_value : NULL,
-                    new_bin, new_len, &entry->row_value));
+                    new_bin, new_len, &entry->row_value),
+                "error in update_row callback for relid %" PRIu64, relid);
     }
     return err;
 }
@@ -237,35 +258,37 @@ int process_frame_delete(avro_value_t *record_val, frame_reader_t reader, uint64
     const void *key_bin = NULL, *old_bin = NULL;
     size_t key_len = 0, old_len = 0;
 
-    check(err, avro_value_get_by_index(record_val, 0, &relid_val, NULL));
-    check(err, avro_value_get_by_index(record_val, 1, &key_val,   NULL));
-    check(err, avro_value_get_by_index(record_val, 2, &old_val,   NULL));
-    check(err, avro_value_get_long(&relid_val, &relid));
-    check(err, avro_value_get_discriminant(&key_val, &key_present));
-    check(err, avro_value_get_discriminant(&old_val, &old_present));
+    check_avro(err, reader, avro_value_get_by_index(record_val, 0, &relid_val, NULL));
+    check_avro(err, reader, avro_value_get_by_index(record_val, 1, &key_val,   NULL));
+    check_avro(err, reader, avro_value_get_by_index(record_val, 2, &old_val,   NULL));
+    check_avro(err, reader, avro_value_get_long(&relid_val, &relid));
+    check_avro(err, reader, avro_value_get_discriminant(&key_val, &key_present));
+    check_avro(err, reader, avro_value_get_discriminant(&old_val, &old_present));
 
     schema_list_entry *entry = schema_list_lookup(reader, relid);
     if (!entry) {
-        avro_set_error("Received delete for unknown relid %u", relid);
-        return EINVAL;
+        return frame_reader_handle(reader, EINVAL,
+                "Received delete for unknown relid %" PRIu64, relid);
     }
 
     if (key_present) {
-        check(err, avro_value_get_current_branch(&key_val, &branch_val));
-        check(err, avro_value_get_bytes(&branch_val, &key_bin, &key_len));
-        check(err, read_entirely(&entry->key_value, entry->avro_reader, key_bin, key_len));
+        check_avro(err, reader, avro_value_get_current_branch(&key_val, &branch_val));
+        check_avro(err, reader, avro_value_get_bytes(&branch_val, &key_bin, &key_len));
+        check(err, read_entirely(reader, &entry->key_value, entry->avro_reader, key_bin, key_len));
     }
 
     if (old_present) {
-        check(err, avro_value_get_current_branch(&old_val, &branch_val));
-        check(err, avro_value_get_bytes(&branch_val, &old_bin, &old_len));
-        check(err, read_entirely(&entry->old_value, entry->avro_reader, old_bin, old_len));
+        check_avro(err, reader, avro_value_get_current_branch(&old_val, &branch_val));
+        check_avro(err, reader, avro_value_get_bytes(&branch_val, &old_bin, &old_len));
+        check(err, read_entirely(reader, &entry->old_value, entry->avro_reader, old_bin, old_len));
     }
 
     if (reader->on_delete_row) {
-        check(err, reader->on_delete_row(reader->cb_context, wal_pos, relid,
+        check_handle(err, reader,
+                reader->on_delete_row(reader->cb_context, wal_pos, relid,
                     key_bin, key_len, key_bin ? &entry->key_value : NULL,
-                    old_bin, old_len, old_bin ? &entry->old_value : NULL));
+                    old_bin, old_len, old_bin ? &entry->old_value : NULL),
+                "error in delete_row callback for relid %" PRIu64, relid);
     }
     return err;
 }
@@ -358,21 +381,29 @@ void frame_reader_free(frame_reader_t reader) {
     free(reader);
 }
 
+int frame_reader_handle(frame_reader_t reader, int err, const char *fmt, ...) {
+    va_list args;
+    va_start(args, fmt);
+    vsnprintf(reader->error, FRAME_READER_ERROR_LEN, fmt, args);
+    va_end(args);
+
+    return err;
+}
+
 /* Parses the contents of a binary-encoded Avro buffer into an Avro value, ensuring
  * that the entire buffer is read. */
-int read_entirely(avro_value_t *value, avro_reader_t reader, const void *buf, size_t len) {
+int read_entirely(frame_reader_t reader, avro_value_t *value, avro_reader_t avro_reader, const void *buf, size_t len) {
     int err = 0;
 
-    avro_reader_memory_set_source(reader, buf, len);
-    check(err, avro_value_read(reader, value));
+    avro_reader_memory_set_source(avro_reader, buf, len);
+    check_avro(err, reader, avro_value_read(avro_reader, value));
 
     // Expect the reading of the Avro value from the buffer to entirely consume the
     // buffer contents. If there's anything left at the end, something must be wrong.
     // Avro doesn't seem to provide a way of checking how many bytes remain, so we
     // test indirectly by trying to seek forward (expecting to see an error).
-    if (avro_skip(reader, 1) != ENOSPC) {
-        avro_set_error("Unexpected trailing bytes at the end of buffer");
-        return EINVAL;
+    if (avro_skip(avro_reader, 1) != ENOSPC) {
+        return frame_reader_handle(reader, EINVAL, "Unexpected trailing bytes at the end of buffer");
     }
 
     return err;

--- a/client/protocol_client.c
+++ b/client/protocol_client.c
@@ -387,7 +387,9 @@ int frame_reader_handle(frame_reader_t reader, int err, const char *fmt, ...) {
     vsnprintf(reader->error, FRAME_READER_ERROR_LEN, fmt, args);
     va_end(args);
 
-    return err;
+    if (reader->on_error) {
+        return reader->on_error(reader->cb_context, err, reader->error);
+    } else return err;
 }
 
 /* Parses the contents of a binary-encoded Avro buffer into an Avro value, ensuring

--- a/client/protocol_client.h
+++ b/client/protocol_client.h
@@ -50,6 +50,8 @@ typedef int (*delete_row_cb)(void *, uint64_t, Oid,
 typedef int (*keepalive_cb)(void *, uint64_t);
 
 
+#define FRAME_READER_ERROR_LEN 512
+
 typedef struct {
     Oid                 relid;       /* Uniquely identifies a table, even when it is renamed */
     avro_schema_t       key_schema;  /* Avro schema for the table's primary key or replica identity */
@@ -78,6 +80,7 @@ typedef struct {
     avro_value_iface_t *frame_iface; /* Avro generic interface for the frame schema */
     avro_value_t frame_value;        /* Avro value for a frame */
     avro_reader_t avro_reader;       /* In-memory buffer reader */
+    char error[FRAME_READER_ERROR_LEN]; /* Buffer for error messages */
 } frame_reader;
 
 typedef frame_reader *frame_reader_t;

--- a/client/protocol_client.h
+++ b/client/protocol_client.h
@@ -49,6 +49,13 @@ typedef int (*delete_row_cb)(void *, uint64_t, Oid,
  *         anything else to signify an error. */
 typedef int (*keepalive_cb)(void *, uint64_t);
 
+/* Parameters: context, err, message
+ * Return: 0 if the error was handled and client should continue;
+ *         nonzero if the error could not be handled and the client should
+ *         report the error to the select loop.
+ */
+typedef int (*error_handler_cb)(void *, int err, const char *);
+
 
 #define FRAME_READER_ERROR_LEN 512
 
@@ -73,6 +80,7 @@ typedef struct {
     update_row_cb on_update_row;     /* Called when a row in a relation is updated */
     delete_row_cb on_delete_row;     /* Called when a row in a relation is deleted */
     keepalive_cb on_keepalive;       /* Called when server sends a keepalive message */
+    error_handler_cb on_error;       /* Called when a frame cannot be read or when a callback returns a nonzero error code */
     int num_schemas;                 /* Number of schemas in use */
     int capacity;                    /* Allocated size of schemas array */
     schema_list_entry **schemas;     /* Array of pointers to schema_list_entry structs */

--- a/client/replication.c
+++ b/client/replication.c
@@ -322,7 +322,7 @@ int parse_xlogdata_message(replication_stream_t stream, char *buf, int buflen) {
 
     int err = parse_frame(stream->frame_reader, wal_pos, buf + hdrlen, buflen - hdrlen);
     if (err) {
-        repl_error(stream, "Error parsing frame data: %s", avro_strerror());
+        repl_error(stream, "Error parsing frame data: %s", stream->frame_reader->error);
     }
 
     stream->recvd_lsn = Max(wal_pos, stream->recvd_lsn);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,23 +38,27 @@ postgres:
   hostname: postgres
   ports:
     - '45432:5432'
-bottledwater-json:
+bottledwater:
   build: ./tmp
   dockerfile: Dockerfile.client
   hostname: bottledwater
+  entrypoint:
+    - /usr/local/bin/bottledwater-docker-wrapper.sh
+    - --allow-unkeyed
+    - --topic-config=message.timeout.ms=2000
+bottledwater-json:
+  extends: {service: bottledwater}
   links:
     - postgres
     - kafka
-  command: --output-format=json --allow-unkeyed
+  command: --output-format=json
 bottledwater-avro:
-  build: ./tmp
-  dockerfile: Dockerfile.client
-  hostname: bottledwater
+  extends: {service: bottledwater}
   links:
     - postgres
     - kafka
     - schema-registry
-  command: --output-format=avro --allow-unkeyed
+  command: --output-format=avro
 psql:
   image: postgres:9.5
   links:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,21 +44,24 @@ bottledwater:
   hostname: bottledwater
   entrypoint:
     - /usr/local/bin/bottledwater-docker-wrapper.sh
-    - --allow-unkeyed
     - --topic-config=message.timeout.ms=2000
+  environment:
+    BOTTLED_WATER_ALLOW_UNKEYED: true
 bottledwater-json:
   extends: {service: bottledwater}
   links:
     - postgres
     - kafka
-  command: --output-format=json
+  environment:
+    BOTTLED_WATER_OUTPUT_FORMAT: json
 bottledwater-avro:
   extends: {service: bottledwater}
   links:
     - postgres
     - kafka
     - schema-registry
-  command: --output-format=avro
+  environment:
+    BOTTLED_WATER_OUTPUT_FORMAT: avro
 psql:
   image: postgres:9.5
   links:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,7 @@ bottledwater:
     - --topic-config=message.timeout.ms=2000
   environment:
     BOTTLED_WATER_ALLOW_UNKEYED: true
+    BOTTLED_WATER_ON_ERROR:
 bottledwater-json:
   extends: {service: bottledwater}
   links:

--- a/kafka/Makefile
+++ b/kafka/Makefile
@@ -1,4 +1,4 @@
-SOURCES=bottledwater.c json.c registry.c table_mapper.c
+SOURCES=bottledwater.c json.c registry.c table_mapper.c logger.c
 EXECUTABLE=bottledwater
 STATICLIB=../client/libbottledwater.a
 

--- a/kafka/bottledwater.c
+++ b/kafka/bottledwater.c
@@ -508,7 +508,7 @@ static void on_deliver_msg(rd_kafka_t *kafka, const rd_kafka_message_t *msg, voi
     msg_envelope_t envelope = (msg_envelope_t) msg->_private;
 
     if (msg->err) {
-        fprintf(stderr, "%s: Message delivery failed: %s\n", progname, rd_kafka_message_errstr(msg));
+        fprintf(stderr, "%s: Message delivery failed: %s\n", progname, rd_kafka_err2str(msg->err));
         exit_nicely(envelope->context, 1);
     } else {
         // Message successfully delivered to Kafka

--- a/kafka/bottledwater.c
+++ b/kafka/bottledwater.c
@@ -454,6 +454,7 @@ static int on_table_schema(void *_context, uint64_t wal_pos, Oid relid,
          * See comment in body of table_mapper_update() in table_mapper.c for
          * discussion of the implications of an error registering the table.
          */
+        return 1;
     }
 
     return 0;
@@ -520,7 +521,8 @@ int send_kafka_msg(producer_context_t context, uint64_t wal_pos, Oid relid,
     size_t key_encoded_len, val_encoded_len;
     table_metadata_t table = table_mapper_lookup(context->mapper, relid);
     if (!table) {
-        fatal_error(context, "relid %" PRIu32 " has no registered schema", relid);
+        log_error("relid %" PRIu32 " has no registered schema", relid);
+        return 1;
     }
 
     int err;

--- a/kafka/bottledwater.c
+++ b/kafka/bottledwater.c
@@ -487,7 +487,8 @@ int send_kafka_msg(producer_context_t context, uint64_t wal_pos, Oid relid,
             backpressure(context);
 
         } else if (err != 0) {
-            fatal_error(context, "Failed to produce to Kafka: %s",
+            fatal_error(context, "Failed to produce to Kafka (topic %s): %s",
+                        rd_kafka_topic_name(table->topic),
                         rd_kafka_err2str(rd_kafka_errno2err(errno)));
         }
     }
@@ -505,7 +506,9 @@ static void on_deliver_msg(rd_kafka_t *kafka, const rd_kafka_message_t *msg, voi
     msg_envelope_t envelope = (msg_envelope_t) msg->_private;
 
     if (msg->err) {
-        fatal_error(envelope->context, "Message delivery failed: %s", rd_kafka_err2str(msg->err));
+        fatal_error(envelope->context, "Message delivery to topic %s failed: %s",
+                    rd_kafka_topic_name(msg->rkt),
+                    rd_kafka_err2str(msg->err));
     } else {
         // Message successfully delivered to Kafka
         envelope->xact->pending_events--;

--- a/kafka/bottledwater.c
+++ b/kafka/bottledwater.c
@@ -376,7 +376,12 @@ static int on_table_schema(void *_context, uint64_t wal_pos, Oid relid,
             key_schema_json, key_schema_len, row_schema_json, row_schema_len);
 
     if (!table) {
-        fatal_error(context, "%s", context->mapper->error);
+        log_error("%s", context->mapper->error);
+        /*
+         * Can't really handle the error since we're in a callback.
+         * See comment in body of table_mapper_update() in table_mapper.c for
+         * discussion of the implications of an error registering the table.
+         */
     }
 
     return 0;

--- a/kafka/bottledwater.c
+++ b/kafka/bottledwater.c
@@ -534,8 +534,9 @@ int send_kafka_msg(producer_context_t context, uint64_t wal_pos, Oid relid,
                 val_bin, val_len, (char **) &val, &val_encoded_len);
 
         if (err) {
-            fatal_error(context, "error %s encoding JSON for topic %s",
-                        strerror(err), rd_kafka_topic_name(table->topic));
+            log_error("%s: error %s encoding JSON for topic %s",
+                      progname, strerror(err), rd_kafka_topic_name(table->topic));
+            return err;
         }
         break;
     case OUTPUT_FORMAT_AVRO:
@@ -544,8 +545,9 @@ int send_kafka_msg(producer_context_t context, uint64_t wal_pos, Oid relid,
                 val_bin, val_len, &val, &val_encoded_len);
 
         if (err) {
-            fatal_error(context, "error %s encoding Avro for topic %s",
-                        strerror(err), rd_kafka_topic_name(table->topic));
+            log_error("%s: error %s encoding Avro for topic %s",
+                      progname, strerror(err), rd_kafka_topic_name(table->topic));
+            return err;
         }
         break;
     default:

--- a/kafka/bottledwater.c
+++ b/kafka/bottledwater.c
@@ -48,22 +48,24 @@
 #define XACT_LIST_LEN (MAX_IN_FLIGHT_TRANSACTIONS + 1)
 
 
-typedef int format_t; /* should always be one of the following constants: */
-#define OUTPUT_FORMAT_UNDEFINED 0
-#define OUTPUT_FORMAT_AVRO 1
-#define OUTPUT_FORMAT_JSON 2
+typedef enum {
+    OUTPUT_FORMAT_UNDEFINED = 0,
+    OUTPUT_FORMAT_AVRO,
+    OUTPUT_FORMAT_JSON
+} format_t;
 
-#define DEFAULT_OUTPUT_FORMAT_NAME "avro"
-#define DEFAULT_OUTPUT_FORMAT OUTPUT_FORMAT_AVRO
+static const char* DEFAULT_OUTPUT_FORMAT_NAME = "avro";
+static const format_t DEFAULT_OUTPUT_FORMAT = OUTPUT_FORMAT_AVRO;
 
 
-typedef int error_policy_t; /* should always be one of the following constants: */
-#define ERROR_POLICY_UNDEFINED 0
-#define ERROR_POLICY_LOG 1
-#define ERROR_POLICY_EXIT 2
+typedef enum {
+    ERROR_POLICY_UNDEFINED = 0,
+    ERROR_POLICY_LOG,
+    ERROR_POLICY_EXIT
+} error_policy_t;
 
-#define DEFAULT_ERROR_POLICY_NAME "exit"
-#define DEFAULT_ERROR_POLICY ERROR_POLICY_EXIT
+static const char* DEFAULT_ERROR_POLICY_NAME = "exit";
+static const error_policy_t DEFAULT_ERROR_POLICY = ERROR_POLICY_EXIT;
 
 
 typedef struct {

--- a/kafka/logger.c
+++ b/kafka/logger.c
@@ -1,0 +1,24 @@
+#include "logger.h"
+
+#include <stdarg.h>
+#include <stdio.h>
+
+
+void daemon_log(log_level level, const char *fmt, ...) {
+    const char *level_str;
+    switch (level) {
+        case LOG_LEVEL_DEBUG: level_str = "DEBUG"; break;
+        case LOG_LEVEL_INFO: level_str = "INFO"; break;
+        case LOG_LEVEL_WARN: level_str = "WARN"; break;
+        case LOG_LEVEL_ERROR: level_str = "ERROR"; break;
+    }
+
+    fprintf(stderr, "[%s] ", level_str);
+
+    va_list args;
+    va_start(args, fmt);
+    vfprintf(stderr, fmt, args);
+    va_end(args);
+
+    fprintf(stderr, "\n");
+}

--- a/kafka/logger.c
+++ b/kafka/logger.c
@@ -5,20 +5,23 @@
 
 
 void daemon_log(log_level level, const char *fmt, ...) {
+    va_list args;
+    va_start(args, fmt);
+    vdaemon_log(level, fmt, args);
+    va_end(args);
+}
+
+void vdaemon_log(log_level level, const char *fmt, va_list args) {
     const char *level_str;
     switch (level) {
         case LOG_LEVEL_DEBUG: level_str = "DEBUG"; break;
         case LOG_LEVEL_INFO: level_str = "INFO"; break;
         case LOG_LEVEL_WARN: level_str = "WARN"; break;
         case LOG_LEVEL_ERROR: level_str = "ERROR"; break;
+        case LOG_LEVEL_FATAL: level_str = "FATAL"; break;
     }
 
     fprintf(stderr, "[%s] ", level_str);
-
-    va_list args;
-    va_start(args, fmt);
     vfprintf(stderr, fmt, args);
-    va_end(args);
-
     fprintf(stderr, "\n");
 }

--- a/kafka/logger.h
+++ b/kafka/logger.h
@@ -1,25 +1,36 @@
 #ifndef LOGGER_H
 #define LOGGER_H
 
+#include <stdarg.h>
+
 
 typedef enum log_level {
   LOG_LEVEL_DEBUG,
   LOG_LEVEL_INFO,
   LOG_LEVEL_WARN,
-  LOG_LEVEL_ERROR
+  LOG_LEVEL_ERROR,
+  LOG_LEVEL_FATAL
 } log_level;
 
 void daemon_log(log_level level, const char *fmt, ...) __attribute__ ((format (printf, 2, 3)));
+void vdaemon_log(log_level level, const char *fmt, va_list args) __attribute__ ((format (printf, 2, 0)));
 
 #ifdef DEBUG
 #define log_debug(...) daemon_log(LOG_LEVEL_DEBUG, __VA_ARGS__)
+#define vlog_debug(args) vdaemon_log(LOG_LEVEL_DEBUG, (args))
 #else
 #define log_debug(...)
+#define vlog_debug(args)
 #endif
 
 #define log_info(...) daemon_log(LOG_LEVEL_INFO, __VA_ARGS__)
+#define vlog_info(args) vdaemon_log(LOG_LEVEL_INFO, (args))
 #define log_warn(...) daemon_log(LOG_LEVEL_WARN, __VA_ARGS__)
+#define vlog_warn(args) vdaemon_log(LOG_LEVEL_WARN, (args))
 #define log_error(...) daemon_log(LOG_LEVEL_ERROR, __VA_ARGS__)
+#define vlog_error(...) vdaemon_log(LOG_LEVEL_ERROR, __VA_ARGS__)
+#define log_fatal(...) daemon_log(LOG_LEVEL_FATAL, __VA_ARGS__)
+#define vlog_fatal(...) vdaemon_log(LOG_LEVEL_FATAL, __VA_ARGS__)
 
 
 #endif /* LOGGER_H */

--- a/kafka/logger.h
+++ b/kafka/logger.h
@@ -1,0 +1,25 @@
+#ifndef LOGGER_H
+#define LOGGER_H
+
+
+typedef enum log_level {
+  LOG_LEVEL_DEBUG,
+  LOG_LEVEL_INFO,
+  LOG_LEVEL_WARN,
+  LOG_LEVEL_ERROR
+} log_level;
+
+void daemon_log(log_level level, const char *fmt, ...) __attribute__ ((format (printf, 2, 3)));
+
+#ifdef DEBUG
+#define log_debug(...) daemon_log(LOG_LEVEL_DEBUG, __VA_ARGS__)
+#else
+#define log_debug(...)
+#endif
+
+#define log_info(...) daemon_log(LOG_LEVEL_INFO, __VA_ARGS__)
+#define log_warn(...) daemon_log(LOG_LEVEL_WARN, __VA_ARGS__)
+#define log_error(...) daemon_log(LOG_LEVEL_ERROR, __VA_ARGS__)
+
+
+#endif /* LOGGER_H */

--- a/kafka/registry.c
+++ b/kafka/registry.c
@@ -10,6 +10,7 @@
  * Anyone who wants to consume the messages can look up the schema ID in the
  * schema registry to obtain the schema, and thus decode the message. */
 
+#include "logger.h"
 #include "registry.h"
 
 #include <avro.h>
@@ -125,9 +126,9 @@ int schema_registry_request(schema_registry_t registry, const char *name, int is
 
     if (!err) {
         *schema_id_out = schema_id;
-        fprintf(stderr, "Registered %s schema for topic \"%s\" with ID %d\n",
-                is_key ? "key" : "value",
-                name, schema_id);
+        log_info("Registered %s schema for topic \"%s\" with ID %d",
+                 is_key ? "key" : "value",
+                 name, schema_id);
     }
 
     destroyPQExpBuffer(response);
@@ -144,7 +145,7 @@ static size_t registry_response_cb(void *data, size_t size, size_t nmemb, void *
     PQExpBuffer buffer = (PQExpBuffer) dest;
     appendBinaryPQExpBuffer(buffer, data, bytes);
     if (PQExpBufferBroken(buffer)) {
-        fprintf(stderr, "Out of memory: response from schema registry is too large\n");
+        log_error("Out of memory: response from schema registry is too large");
         return 0;
     }
     return bytes;

--- a/kafka/table_mapper.h
+++ b/kafka/table_mapper.h
@@ -22,6 +22,7 @@ typedef struct {
     avro_schema_t key_schema;   /* Schema to use for converting key values to JSON */
     int row_schema_id;          /* Identifier for the current row schema, assigned by the registry */
     avro_schema_t row_schema;   /* Schema to use for converting row values to JSON */
+    char deleted;               /* Whether this table record has been deleted */
 } table_metadata;
 
 typedef table_metadata *table_metadata_t;

--- a/spec/functional/outage_spec.rb
+++ b/spec/functional/outage_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+require 'test_cluster'
+
+describe 'outages', functional: true do
+  after(:example) do
+    TEST_CLUSTER.stop(dump_logs: false)
+  end
+
+  let(:postgres) { TEST_CLUSTER.postgres }
+
+  example 'BW should not crash if Kafka is down' do
+    pending 'make publish errors non-fatal'
+
+    TEST_CLUSTER.start(without: [:kafka])
+
+    postgres.exec('CREATE TABLE things (id SERIAL PRIMARY KEY, thing INTEGER NOT NULL)')
+    postgres.exec('INSERT INTO things (thing) VALUES (42)')
+    sleep 5
+
+    expect(TEST_CLUSTER.bottledwater_running?).to be_truthy
+  end
+
+  example 'BW in Avro mode should not crash if the schema registry is down' do
+    pending 'make table mapping errors non-fatal'
+
+    TEST_CLUSTER.bottledwater_format = :avro
+    TEST_CLUSTER.start(without: [:'schema-registry'])
+
+    postgres.exec('CREATE TABLE things (id SERIAL PRIMARY KEY, thing INTEGER NOT NULL)')
+    postgres.exec('INSERT INTO things (thing) VALUES (42)')
+    sleep 5
+
+    expect(TEST_CLUSTER.bottledwater_running?).to be_truthy
+  end
+end

--- a/spec/functional/outage_spec.rb
+++ b/spec/functional/outage_spec.rb
@@ -21,8 +21,6 @@ describe 'outages', functional: true do
   end
 
   example 'BW in Avro mode should not crash if the schema registry is down' do
-    pending 'make table mapping errors non-fatal'
-
     TEST_CLUSTER.bottledwater_format = :avro
     TEST_CLUSTER.start(without: [:'schema-registry'])
 

--- a/spec/functional/outage_spec.rb
+++ b/spec/functional/outage_spec.rb
@@ -8,26 +8,77 @@ describe 'outages', functional: true do
 
   let(:postgres) { TEST_CLUSTER.postgres }
 
-  example 'BW should not crash if Kafka is down' do
-    pending 'make publish errors non-fatal'
+  describe 'with --on-error=exit' do
+    before(:example) do
+      TEST_CLUSTER.bottledwater_on_error = :exit
+    end
 
-    TEST_CLUSTER.start(without: [:kafka])
+    example 'BW crashes after publishing a message if Kafka is down' do
+      TEST_CLUSTER.start(without: [:kafka])
 
-    postgres.exec('CREATE TABLE things (id SERIAL PRIMARY KEY, thing INTEGER NOT NULL)')
-    postgres.exec('INSERT INTO things (thing) VALUES (42)')
-    sleep 5
+      postgres.exec('CREATE TABLE things (id SERIAL PRIMARY KEY, thing INTEGER NOT NULL)')
+      postgres.exec('INSERT INTO things (thing) VALUES (42)')
+      sleep 5
 
-    expect(TEST_CLUSTER.bottledwater_running?).to be_truthy
+      expect(TEST_CLUSTER.bottledwater_running?).to be_falsy
+    end
+
+    describe 'in Avro mode if the schema registry is down' do
+      before(:example) do
+        TEST_CLUSTER.bottledwater_format = :avro
+        TEST_CLUSTER.start(without: [:'schema-registry'])
+
+        postgres.exec('CREATE TABLE things (id SERIAL PRIMARY KEY, thing INTEGER NOT NULL)')
+      end
+
+      example 'initial message crashes Bottled Water' do
+        postgres.exec('INSERT INTO things (thing) VALUES (42)')
+        sleep 5
+
+        expect(TEST_CLUSTER.bottledwater_running?).to be_falsy
+      end
+    end
   end
 
-  example 'BW in Avro mode should not crash if the schema registry is down' do
-    TEST_CLUSTER.bottledwater_format = :avro
-    TEST_CLUSTER.start(without: [:'schema-registry'])
+  describe 'with --on-error=log' do
+    before(:example) do
+      TEST_CLUSTER.bottledwater_on_error = :log
+    end
 
-    postgres.exec('CREATE TABLE things (id SERIAL PRIMARY KEY, thing INTEGER NOT NULL)')
-    postgres.exec('INSERT INTO things (thing) VALUES (42)')
-    sleep 5
+    example 'BW does not crash if Kafka is down' do
+      TEST_CLUSTER.start(without: [:kafka])
 
-    expect(TEST_CLUSTER.bottledwater_running?).to be_truthy
+      postgres.exec('CREATE TABLE things (id SERIAL PRIMARY KEY, thing INTEGER NOT NULL)')
+      postgres.exec('INSERT INTO things (thing) VALUES (42)')
+      sleep 5
+
+      expect(TEST_CLUSTER.bottledwater_running?).to be_truthy
+    end
+
+    describe 'in Avro mode if the schema registry is down' do
+      before(:example) do
+        TEST_CLUSTER.bottledwater_format = :avro
+        TEST_CLUSTER.start(without: [:'schema-registry'])
+
+        postgres.exec('CREATE TABLE things (id SERIAL PRIMARY KEY, thing INTEGER NOT NULL)')
+      end
+
+      example 'initial message does not crash Bottled Water' do
+        postgres.exec('INSERT INTO things (thing) VALUES (42)')
+        sleep 5
+
+        expect(TEST_CLUSTER.bottledwater_running?).to be_truthy
+      end
+
+      example 'subsequent messages do not crash Bottled Water' do
+        postgres.exec('INSERT INTO things (thing) VALUES (42)')
+        sleep 1
+
+        postgres.exec('INSERT INTO things (thing) VALUES (43)')
+        sleep 5
+
+        expect(TEST_CLUSTER.bottledwater_running?).to be_truthy
+      end
+    end
   end
 end

--- a/spec/functional/topic_spec.rb
+++ b/spec/functional/topic_spec.rb
@@ -63,14 +63,16 @@ describe 'topics', functional: true do
       TEST_CLUSTER.stop
     end
 
-    example 'inserting rows in a new table crashes Bottled Water' do
+    example 'inserting rows in a new table does not crash Bottled Water' do
+      pending 'make publish errors non-fatal'
+
       expect(TEST_CLUSTER.bottledwater_running?).to be_truthy
 
       postgres.exec('CREATE TABLE things (id SERIAL PRIMARY KEY, thing INTEGER NOT NULL)')
       postgres.exec('INSERT INTO things (thing) VALUES (42)')
       sleep 5
 
-      expect(TEST_CLUSTER.bottledwater_running?).to be_falsey
+      expect(TEST_CLUSTER.bottledwater_running?).to be_truthy
     end
 
     example 'inserting rows in a new table after creating the topic does not crash Bottled Water' do
@@ -79,6 +81,63 @@ describe 'topics', functional: true do
 
       postgres.exec('CREATE TABLE items (id SERIAL PRIMARY KEY, item INTEGER NOT NULL)')
       postgres.exec('INSERT INTO items (item) VALUES (42)')
+      sleep 5
+
+      expect(TEST_CLUSTER.bottledwater_running?).to be_truthy
+    end
+
+    example 'renaming a table, creating the new topic, then inserting does not crash Bottled Water' do
+      expect(TEST_CLUSTER.bottledwater_running?).to be_truthy
+
+      kazoo.create_topic('users', partitions: 1, replication_factor: 1)
+      kazoo.create_topic('members', partitions: 1, replication_factor: 1)
+      sleep 1
+
+      postgres.exec('CREATE TABLE users (id SERIAL PRIMARY KEY, age INTEGER NOT NULL)')
+      postgres.exec('INSERT INTO users (age) VALUES (31)')
+      sleep 1
+      postgres.exec('ALTER TABLE users RENAME TO members')
+      postgres.exec('INSERT INTO members (age) VALUES (42)')
+
+      sleep 5
+
+      expect(TEST_CLUSTER.bottledwater_running?).to be_truthy
+    end
+
+    example 'altering table schema then inserting does not crash Bottled Water' do
+      expect(TEST_CLUSTER.bottledwater_running?).to be_truthy
+
+      kazoo.create_topic('customers', partitions: 1, replication_factor: 1)
+      sleep 1
+
+      postgres.exec('CREATE TABLE customers (age INTEGER NOT NULL)')
+      postgres.exec('INSERT INTO customers (age) VALUES (31)')
+      sleep 1
+      postgres.exec('ALTER TABLE customers ADD COLUMN name TEXT NULL')
+      postgres.exec("INSERT INTO customers (age, name) VALUES (42, 'Ron Swanson')")
+
+      sleep 5
+
+      expect(TEST_CLUSTER.bottledwater_running?).to be_truthy
+    end
+
+    example 'adding a primary key to a table then inserting does not crash Bottled Water' do
+      # We test this separately from the previous ALTER TABLE ... ADD COLUMN
+      # because when adding a new primary key, Postgres first creates a
+      # temporary table, which Bottled Water picks up as a new table to stream.
+      pending 'make publish errors non-fatal'
+
+      expect(TEST_CLUSTER.bottledwater_running?).to be_truthy
+
+      kazoo.create_topic('products', partitions: 1, replication_factor: 1)
+      sleep 1
+
+      postgres.exec('CREATE TABLE products (sku INTEGER NOT NULL)')
+      postgres.exec('INSERT INTO products (sku) VALUES (31)')
+      sleep 1
+      postgres.exec('ALTER TABLE products ADD COLUMN id SERIAL PRIMARY KEY')
+      postgres.exec('INSERT INTO products (sku) VALUES (42)')
+
       sleep 5
 
       expect(TEST_CLUSTER.bottledwater_running?).to be_truthy

--- a/spec/functional/topic_spec.rb
+++ b/spec/functional/topic_spec.rb
@@ -56,6 +56,13 @@ describe 'topics', functional: true do
     before(:context) do
       TEST_CLUSTER.kafka_auto_create_topics_enable = false
       TEST_CLUSTER.bottledwater_on_error = :exit
+
+      # Some of these tests create tables without a primary key.  Kafka 0.9
+      # rejects unkeyed messages sent to a compacted table, but we set
+      # compaction as default in test_cluster.rb, so we need to explicitly
+      # disable it for these tests.
+      TEST_CLUSTER.kafka_log_cleanup_policy = :delete
+
       TEST_CLUSTER.start
     end
 
@@ -145,6 +152,13 @@ describe 'topics', functional: true do
     before(:context) do
       TEST_CLUSTER.kafka_auto_create_topics_enable = false
       TEST_CLUSTER.bottledwater_on_error = :log
+
+      # Some of these tests create tables without a primary key.  Kafka 0.9
+      # rejects unkeyed messages sent to a compacted table, but we set
+      # compaction as default in test_cluster.rb, so we need to explicitly
+      # disable it for these tests.
+      TEST_CLUSTER.kafka_log_cleanup_policy = :delete
+
       TEST_CLUSTER.start
     end
 

--- a/spec/test_cluster.rb
+++ b/spec/test_cluster.rb
@@ -38,6 +38,7 @@ class TestCluster
     self.kafka_auto_create_topics_enable = true
 
     self.bottledwater_format = :json
+    self.bottledwater_on_error = :exit
   end
 
   def start(without: [])
@@ -113,6 +114,10 @@ class TestCluster
 
   def bottledwater_service
     :"bottledwater-#{bottledwater_format}"
+  end
+
+  def bottledwater_on_error=(policy)
+    ENV['BOTTLED_WATER_ON_ERROR'] = policy.to_s
   end
 
   def schema_registry_needed?


### PR DESCRIPTION
This PR revamps Bottled Water's logging and error handling, with a primary goal of supporting an more forgiving error handling policy.

If Bottled Water encounters an error - such as failure to communicate with Kafka or the Schema Registry - its behaviour prior to this PR is for the client to exit, halting the flow of data into Kafka.  Since Postgres will retain and replay the logical replication stream until Bottled Water acknowledges it, this policy ensures that:

 * BW will never miss an update (every update made in Postgres will eventually be written to Kafka) - _provided_ that whatever caused the error is resolved externally (e.g.  restoring connectivity to Kafka) and the Bottled Water client is then restarted;

 * BW will never write corrupted data to Kafka: e.g. if unable to obtain a schema id from the Schema Registry for the current update, rather than writing to Kafka without a schema id (which would leave consumers unable to parse the update), it will wait until the problem is resolved.

However, in some scenarios, exiting on the first error may not be desirable:

 * if there is an error publishing for one table (e.g. if Kafka is configured not to autocreate topics and the corresponding topic has not been explicitly created), you may not want to halt updates for all other tables.

 * if the reason for the error cannot be resolved quickly (e.g. Kafka misconfiguration or prolonged outage), Bottled Water may threaten the stability of the Postgres server.  This is because Postgres will store WAL on disk for all updates made since Bottled Water last acknowledged (i.e. successfully published) an update.  If Postgres has a high write throughput, Bottled Water being unavailable may cause the disk on the Postgres server to fill up, likely causing Postgres to crash.

To support these scenarios, this PR adds an alternative error handling policy where BW will simply log that the error occurred and drop the update it was attempting to process, acknowledging the update so that Postgres can stop retaining WAL.  This policy can be enabled via the `--on-error` command-line switch.  N.B. that in this mode Bottled Water can no longer guarantee to never miss an update.