### PR TITLE
Use consistent_random partitioner if available

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ For that to work, you need the following dependencies installed:
   (Homebrew: `brew install jansson`; Ubuntu: `sudo apt-get install libjansson-dev`)
 * [libcurl](http://curl.haxx.se/libcurl/), a HTTP client.
   (Homebrew: `brew install curl`; Ubuntu: `sudo apt-get install libcurl4-openssl-dev`)
-* [librdkafka](https://github.com/edenhill/librdkafka) (0.9.0 or later), a Kafka client.
+* [librdkafka](https://github.com/edenhill/librdkafka) (0.9.1 or later), a Kafka client.
   (Ubuntu universe: `sudo apt-get install librdkafka-dev`, but see [known gotchas](#known-gotchas-with-older-librdkafka-versions); others: build from source)
 
 You can see the Dockerfile for
@@ -251,7 +251,7 @@ programming languages.  JSON output does not require a schema registry.
 Known gotchas with older librdkafka versions
 --------------------------------------------
 
-It is recommended to compile Bottled Water against librdkafka version 0.9.0 or
+It is recommended to compile Bottled Water against librdkafka version 0.9.1 or
 later.  However, Bottled Water will work with older librdkafka versions, with
 degraded functionality.
 

--- a/build/Dockerfile.build
+++ b/build/Dockerfile.build
@@ -12,7 +12,8 @@
 
 FROM postgres:9.5
 
-ENV RDKAFKA_VERSION=0.9.0 \
+ENV RDKAFKA_VERSION=0.9.1 \
+    RDKAFKA_SHASUM="b9d0dd1de53d9f566312c4dd148a4548b4e9a6c2  /root/librdkafka-0.9.1.tar.gz" \
     AVRO_C_VERSION=1.8.0 \
     AVRO_C_SHASUM="af7757633ccf067b1f140c58161e2cdc2f2f003d  /root/avro-c-1.8.0.tar.gz"
 
@@ -45,7 +46,8 @@ RUN curl -o /root/avro-c-${AVRO_C_VERSION}.tar.gz -SL http://archive.apache.org/
     tar czf avro.tar.gz usr/local/include/avro usr/local/lib/libavro* usr/local/lib/pkgconfig/avro-c.pc
 
 # librdkafka
-RUN curl -o /root/librdkafka-${RDKAFKA_VERSION}.tar.gz -SL https://github.com/edenhill/librdkafka/archive/v${RDKAFKA_VERSION}.tar.gz && \
+RUN curl -o /root/librdkafka-${RDKAFKA_VERSION}.tar.gz -SL https://github.com/edenhill/librdkafka/archive/${RDKAFKA_VERSION}.tar.gz && \
+    echo "${RDKAFKA_SHASUM}" | shasum -a 1 -b -c && \
     tar -xzf /root/librdkafka-${RDKAFKA_VERSION}.tar.gz -C /root && \
     cd /root/librdkafka-${RDKAFKA_VERSION} && ./configure && make && make install && cd / && \
     tar czf librdkafka.tar.gz usr/local/include/librdkafka usr/local/lib/librdkafka*

--- a/kafka/bottledwater.c
+++ b/kafka/bottledwater.c
@@ -629,11 +629,30 @@ producer_context_t init_producer(client_context_t client) {
      * in the circular buffer starting out empty, since the tail is one ahead
      * of the head. */
 
-#if RD_KAFKA_VERSION >= 0x00090000
-    // librdkafka 0.9.0 includes an implementation of a "consistent hashing
-    // partitioner", which we can use to ensure that all updates for a given
-    // key go to the same partition.
+#if RD_KAFKA_VERSION >= 0x00090100
+    /* librdkafka 0.9.1 provides a "consistent_random" partitioner, which is
+     * a good choice for us: "Uses consistent hashing to map identical keys
+     * onto identical partitions, and messages without keys will be assigned
+     * via the random partitioner." */
+    rd_kafka_topic_conf_set_partitioner_cb(context->topic_conf, &rd_kafka_msg_partitioner_consistent_random);
+#elif RD_KAFKA_VERSION >= 0x00090000
+#warning "rdkafka 0.9.0, using consistent partitioner - unkeyed messages will all get sent to a single partition!"
+    /* librdkafka 0.9.0 provides a "consistent hashing partitioner", which we
+     * can use to ensure that all updates for a given key go to the same
+     * partition.  However, for unkeyed messages (such as we send for tables
+     * with no primary key), it sends them all to the same partition, rather
+     * than randomly partitioning them as would be preferable for scalability.
+     */
     rd_kafka_topic_conf_set_partitioner_cb(context->topic_conf, &rd_kafka_msg_partitioner_consistent);
+#else
+#warning "rdkafka older than 0.9.0, messages will be partitioned randomly!"
+    /* librdkafka prior to 0.9.0 does not provide a consistent partitioner, so
+     * each message will be assigned to a random partition.  This will lead to
+     * incorrect log compaction behaviour: e.g. if the initial insert for row
+     * 42 goes to partition 0, then a subsequent delete for row 42 goes to
+     * partition 1, then log compaction will be unable to garbage-collect the
+     * insert. It will also break any consumer relying on seeing all updates
+     * relating to a given key (e.g. for a stream-table join). */
 #endif
 
     set_topic_config(context, "produce.offset.report", "true");

--- a/kafka/bottledwater.c
+++ b/kafka/bottledwater.c
@@ -629,7 +629,7 @@ producer_context_t init_producer(client_context_t client) {
      * in the circular buffer starting out empty, since the tail is one ahead
      * of the head. */
 
-#if RD_KAFKA_VERSION >= 0x00090100
+#if RD_KAFKA_VERSION >= 0x000901ff
     /* librdkafka 0.9.1 provides a "consistent_random" partitioner, which is
      * a good choice for us: "Uses consistent hashing to map identical keys
      * onto identical partitions, and messages without keys will be assigned

--- a/spec/functional/partitioning_spec.rb
+++ b/spec/functional/partitioning_spec.rb
@@ -106,7 +106,7 @@ describe 'partitioning', functional: true, format: :json do
       expect(partitions.size).to eq(2)
       messages_0, messages_1 = partitions.values
 
-      expect(messages_0.size).to be_within(10).of(messages_1.size)
+      expect(messages_0.size).to be_within(20).of(messages_1.size)
     end
   end
 end

--- a/spec/functional/partitioning_spec.rb
+++ b/spec/functional/partitioning_spec.rb
@@ -4,6 +4,13 @@ require 'format_contexts'
 describe 'partitioning', functional: true, format: :json do
   before(:context) do
     require 'test_cluster'
+
+    # Some of these tests create tables without a primary key.  Kafka 0.9
+    # rejects unkeyed messages sent to a compacted table, but we set
+    # compaction as default in test_cluster.rb, so we need to explicitly
+    # disable it for these tests.
+    TEST_CLUSTER.kafka_log_cleanup_policy = :delete
+
     TEST_CLUSTER.start
   end
 
@@ -14,73 +21,92 @@ describe 'partitioning', functional: true, format: :json do
   let(:postgres) { TEST_CLUSTER.postgres }
   let(:kazoo) { TEST_CLUSTER.kazoo }
 
-  example 'messages are partitioned evenly' do
-    kazoo.create_topic('items', partitions: 2, replication_factor: 1)
+  describe 'keyed table' do
+    example 'messages are partitioned evenly' do
+      kazoo.create_topic('items', partitions: 2, replication_factor: 1)
 
-    postgres.exec('CREATE TABLE items (id SERIAL PRIMARY KEY, item INTEGER NOT NULL)')
+      postgres.exec('CREATE TABLE items (id SERIAL PRIMARY KEY, item INTEGER NOT NULL)')
 
-    postgres.exec('INSERT INTO items (item) SELECT * FROM generate_series(1, 100) AS item')
-    sleep 1
+      postgres.exec('INSERT INTO items (item) SELECT * FROM generate_series(1, 100) AS item')
+      sleep 1
 
-    partitions = kafka_take_messages('items', 100, collect_partitions: true)
-    expect(partitions.size).to eq(2)
-    messages_0, messages_1 = partitions.values
+      partitions = kafka_take_messages('items', 100, collect_partitions: true)
+      expect(partitions.size).to eq(2)
+      messages_0, messages_1 = partitions.values
 
-    expect(messages_0.size).to be_within(10).of(messages_1.size)
-  end
+      expect(messages_0.size).to be_within(10).of(messages_1.size)
+    end
 
-  example 'inserts and deletes for a given key go to the same partition' do
-    kazoo.create_topic('numbers', partitions: 2, replication_factor: 1)
+    example 'inserts and deletes for a given key go to the same partition' do
+      kazoo.create_topic('numbers', partitions: 2, replication_factor: 1)
 
-    postgres.exec('CREATE TABLE numbers (id SERIAL PRIMARY KEY, number INTEGER NOT NULL)')
+      postgres.exec('CREATE TABLE numbers (id SERIAL PRIMARY KEY, number INTEGER NOT NULL)')
 
-    postgres.exec('INSERT INTO numbers (number) SELECT * from generate_series(11, 20) AS number')
-    sleep 1
+      postgres.exec('INSERT INTO numbers (number) SELECT * from generate_series(11, 20) AS number')
+      sleep 1
 
-    postgres.exec('DELETE FROM numbers')
+      postgres.exec('DELETE FROM numbers')
 
-    partitions = kafka_take_messages('numbers', 20, collect_partitions: true)
+      partitions = kafka_take_messages('numbers', 20, collect_partitions: true)
 
-    partitions.each do |partition, messages|
-      # each key should have two messages, an insert followed by a delete
-      messages.group_by(&:key).each do |key, messages_for_key|
-        expect(messages_for_key.size).to eq(2)
+      partitions.each do |partition, messages|
+        # each key should have two messages, an insert followed by a delete
+        messages.group_by(&:key).each do |key, messages_for_key|
+          expect(messages_for_key.size).to eq(2)
 
-        insert, delete = messages_for_key
-        expect(insert.value).to_not be_nil
-        expect(delete.value).to be_nil
+          insert, delete = messages_for_key
+          expect(insert.value).to_not be_nil
+          expect(delete.value).to be_nil
+        end
+      end
+    end
+
+    example 'inserts and updates for a given key go to the same partition' do
+      kazoo.create_topic('things', partitions: 2, replication_factor: 1)
+
+      postgres.exec('CREATE TABLE things (id SERIAL PRIMARY KEY, thing INTEGER NOT NULL)')
+
+      result = postgres.exec('INSERT INTO things (thing) SELECT * from generate_series(11, 20) AS thing RETURNING id')
+      ids = result.map {|row| row.fetch('id') }
+      sleep 1
+
+      # make sure there's no ordering dependency
+      ids.shuffle!
+
+      ids.each do |id|
+        postgres.exec_params('UPDATE things SET thing = thing + 1 WHERE id = $1', [id])
+      end
+
+      partitions = kafka_take_messages('things', 20, collect_partitions: true)
+
+      partitions.each do |partition, messages|
+        # each key should have two messages, the second with an incremented value
+        messages.group_by(&:key).each do |key, messages_for_key|
+          expect(messages_for_key.size).to eq(2)
+
+          insert, update = messages_for_key
+          insert_value = fetch_int(decode_value(insert.value), 'thing')
+          update_value = fetch_int(decode_value(update.value), 'thing')
+          expect(update_value).to eq(insert_value + 1)
+        end
       end
     end
   end
 
-  example 'inserts and updates for a given key go to the same partition' do
-    kazoo.create_topic('things', partitions: 2, replication_factor: 1)
+  describe 'unkeyed table' do
+    example 'messages are partitioned evenly' do
+      kazoo.create_topic('events', partitions: 2, replication_factor: 1)
 
-    postgres.exec('CREATE TABLE things (id SERIAL PRIMARY KEY, thing INTEGER NOT NULL)')
+      postgres.exec('CREATE TABLE events (event TEXT)')
 
-    result = postgres.exec('INSERT INTO things (thing) SELECT * from generate_series(11, 20) AS thing RETURNING id')
-    ids = result.map {|row| row.fetch('id') }
-    sleep 1
+      postgres.exec("INSERT INTO events (event) SELECT 'event ' || num AS event FROM generate_series(1, 100) AS num")
+      sleep 1
 
-    # make sure there's no ordering dependency
-    ids.shuffle!
+      partitions = kafka_take_messages('events', 100, collect_partitions: true)
+      expect(partitions.size).to eq(2)
+      messages_0, messages_1 = partitions.values
 
-    ids.each do |id|
-      postgres.exec_params('UPDATE things SET thing = thing + 1 WHERE id = $1', [id])
-    end
-
-    partitions = kafka_take_messages('things', 20, collect_partitions: true)
-
-    partitions.each do |partition, messages|
-      # each key should have two messages, the second with an incremented value
-      messages.group_by(&:key).each do |key, messages_for_key|
-        expect(messages_for_key.size).to eq(2)
-
-        insert, update = messages_for_key
-        insert_value = fetch_int(decode_value(insert.value), 'thing')
-        update_value = fetch_int(decode_value(update.value), 'thing')
-        expect(update_value).to eq(insert_value + 1)
-      end
+      expect(messages_0.size).to be_within(10).of(messages_1.size)
     end
   end
 end


### PR DESCRIPTION
librdkafka 0.9.1 provides a ["consistent_random" partitioner](https://github.com/edenhill/librdkafka/blob/c56ac0447cde9003caacee7487b15396182d90e2/src/rdkafka.h#L1181-L1198), which is a good choice for us:

> "Uses consistent hashing to map identical keys onto identical partitions, and messages without keys will be assigned via the random partitioner."

This is an improvement on #39 which configured BW to use the "consistent" partitioner in librdkafka 0.9.0, for two reasons:

 * consistent_random ensures unkeyed messages are evenly partitioned
 * librdkafka 0.9.0 was never actually released

Since consistent_random provides exactly the semantics Bottled Water needs, I'm configuring it explicitly, rather than simply accepting it as the default.  This means if future rdkafka releases change the default partitioner, we will not inherit that change.  (This seems unlikely to happen in practice, since rdkafka [explicitly decided to change the default](https://github.com/edenhill/librdkafka/pull/548) to match the default behaviour of the Java client.)

This PR also updates the README to recommend 0.9.1, updates the Docker setup to build with 0.9.1, adds partitioning tests for unkeyed tables, and adds a compile-time warning if building against anything older than 0.9.1.