### PR TITLE
Use container hostnames instead of link environment variables

### DIFF
--- a/build/Dockerfile.postgres
+++ b/build/Dockerfile.postgres
@@ -11,8 +11,8 @@
 #
 # To connect to the running container with psql:
 #
-#   docker run -it --rm --link postgres:postgres postgres:9.5 \
-#     sh -c 'exec psql -h "$POSTGRES_PORT_5432_TCP_ADDR" -p "$POSTGRES_PORT_5432_TCP_PORT" -U postgres'
+#   docker run -it --rm --link postgres postgres:9.5 \
+#     psql -h postgres -U postgres
 #
 # In the psql session, type the following to enable the plugin:
 #

--- a/build/bottledwater-docker-wrapper.sh
+++ b/build/bottledwater-docker-wrapper.sh
@@ -1,12 +1,11 @@
 #!/bin/sh
 
-POSTGRES_CONNECTION_STRING="hostaddr=$POSTGRES_PORT_5432_TCP_ADDR port=$POSTGRES_PORT_5432_TCP_PORT dbname=postgres user=postgres"
-KAFKA_BROKER="$KAFKA_PORT_9092_TCP_ADDR:$KAFKA_PORT_9092_TCP_PORT"
+POSTGRES_CONNECTION_STRING="host=postgres port=5432 dbname=postgres user=postgres"
+KAFKA_BROKER="kafka:9092"
 
-if [ -n "$SCHEMA_REGISTRY_PORT_8081_TCP_ADDR" ]; then
-  SCHEMA_REGISTRY_URL="http://${SCHEMA_REGISTRY_PORT_8081_TCP_ADDR}:${SCHEMA_REGISTRY_PORT_8081_TCP_PORT}"
-
-  schema_registry_opts="--schema-registry=$SCHEMA_REGISTRY_URL"
+# do we have a link to the schema-registry container?
+if getent hosts schema-registry >/dev/null; then
+  schema_registry_opts="--schema-registry=http://schema-registry:8081"
 else
   schema_registry_opts=
 fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,17 +59,22 @@ psql:
   image: postgres:9.5
   links:
     - postgres
-  command: 'sh -c ''exec psql -h "$POSTGRES_PORT_5432_TCP_ADDR" -p "$POSTGRES_PORT_5432_TCP_PORT" -U postgres'''
+  entrypoint: ['psql', '-h', 'postgres', '-U', 'postgres']
+kafka-console-consumer:
+  image: confluent/tools:0.9.0.0-cp1
+  links:
+    - zookeeper
+    - kafka
+  entrypoint: ['kafka-console-consumer', '--zookeeper', 'zookeeper:2181']
 kafka-avro-console-consumer:
   image: confluent/tools:0.9.0.0-cp1
   links:
     - zookeeper
     - kafka
     - schema-registry
-  entrypoint: ['/confluent-tools.sh', 'kafka-avro-console-consumer']
+  entrypoint: ['kafka-avro-console-consumer', '--zookeeper', 'zookeeper:2181', '--property', 'schema.registry.url=http://schema-registry:8081']
 kafka-tools:
   image: confluent/tools:0.9.0.0-cp1
   links:
     - zookeeper
     - kafka
-  entrypoint: /confluent-tools.sh


### PR DESCRIPTION
Docker populates environment variables for each container link, but
those environment variables are deprecated (as are links themselves):
see https://docs.docker.com/compose/link-env-deprecated/.  This stops
relying on those environment variables in our Docker setup, and instead
addresses containers by hostname.

For links, Docker populates /etc/hosts with suitable hostnames.  The
hostname method should also work when we move from links to Docker
networks, where Docker provides DNS resolution for container names.

This was mainly prompted (see #79) by a change in the confluent/tools
Docker image, which used to provide a wrapper script that read the
environment variables and started up the tools with the appropriate
arguments.  Now that script is no longer available as an entrypoint
(only as a script that generates aliases), so we need to pass the
arguments ourselves.

This also adds a `kafka-console-consumer` service to mirror `kafka-avro-console-consumer`; both have config populated by Docker Compose, so you can switch from consuming one format to the other by just changing the name, and both take all the normal arguments (`--from-beginning`, `--topic`, etc).