### PR TITLE
Build Docker images for Postgres 9.4 and 9.5, and test both

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ test-deps: test-bundle spec/functional/type_specs.rb
 test: test-deps
 	bundle exec rspec --order random
 
-docker: docker-client docker-postgres
+docker: docker-client docker-postgres docker-postgres94
 
 docker-compose: docker
 	docker-compose build
@@ -34,11 +34,17 @@ docker-compose: docker
 tmp:
 	mkdir tmp
 
+tmp/%-94.tar.gz: tmp docker-build-94
+	docker run --rm bwbuild-94:$(DOCKER_TAG) cat /$*-94.tar.gz > $@
+
 tmp/%.tar.gz: tmp docker-build
 	docker run --rm bwbuild:$(DOCKER_TAG) cat /$*.tar.gz > $@
 
 tmp/%: build/% tmp
 	cp $< $@
+
+docker-build-94:
+	docker build -f build/Dockerfile.build94 -t bwbuild-94:$(DOCKER_TAG) .
 
 docker-build:
 	docker build -f build/Dockerfile.build -t bwbuild:$(DOCKER_TAG) .
@@ -48,3 +54,6 @@ docker-client: tmp/Dockerfile.client tmp/avro.tar.gz tmp/librdkafka.tar.gz tmp/b
 
 docker-postgres: tmp/Dockerfile.postgres tmp/bottledwater-ext.tar.gz tmp/avro.tar.gz tmp/replication-config.sh
 	docker build -f $< -t local-postgres-bw:$(DOCKER_TAG) tmp
+
+docker-postgres94: tmp/Dockerfile.postgres94 tmp/bottledwater-ext-94.tar.gz tmp/avro.tar.gz tmp/replication-config.sh
+	docker build -f $< -t local-postgres94-bw:$(DOCKER_TAG) tmp

--- a/build/Dockerfile.build94
+++ b/build/Dockerfile.build94
@@ -1,0 +1,61 @@
+# Builds Bottled Water and its dependencies inside a Docker container.
+# The resulting image is quite large, because all the development tools
+# are installed into it. However, the build process generates tar'ed
+# binaries which you can copy out and apply to a base Postgres image.
+#
+# The Makefile provides a 'docker' target that automates this process:
+#
+#   $ make docker
+#
+# See the Makefile and the other Dockerfiles in this directory for more
+# detail on how the build artifacts are used.
+
+FROM postgres:9.4
+
+ENV RDKAFKA_VERSION=0.9.1 \
+    RDKAFKA_SHASUM="b9d0dd1de53d9f566312c4dd148a4548b4e9a6c2  /root/librdkafka-0.9.1.tar.gz" \
+    AVRO_C_VERSION=1.8.0 \
+    AVRO_C_SHASUM="af7757633ccf067b1f140c58161e2cdc2f2f003d  /root/avro-c-1.8.0.tar.gz"
+
+RUN apt-get update && \
+    # --force-yes is needed because we may need to downgrade libpq5 to $PG_MAJOR
+    # (set by the postgres:9.5 Docker image).  Confusingly the postgres:x.y
+    # Docker images have been known to include libpq5 version > x.y, which we
+    # may not yet be compatible with, so we can't rely on just specifying the
+    # image tag to pin the libpq version.
+    apt-get install -y --no-install-recommends --force-yes \
+        build-essential \
+        ca-certificates \
+        cmake \
+        curl \
+        libcurl4-openssl-dev \
+        libjansson-dev \
+        libpq5=${PG_MAJOR}\* \
+        libpq-dev=${PG_MAJOR}\* \
+        pkg-config \
+        postgresql-server-dev-${PG_MAJOR}=${PG_MAJOR}\*
+
+# Avro
+RUN curl -o /root/avro-c-${AVRO_C_VERSION}.tar.gz -SL http://archive.apache.org/dist/avro/avro-${AVRO_C_VERSION}/c/avro-c-${AVRO_C_VERSION}.tar.gz && \
+    echo "${AVRO_C_SHASUM}" | shasum -a 1 -b -c && \
+    tar -xzf /root/avro-c-${AVRO_C_VERSION}.tar.gz -C /root && \
+    mkdir /root/avro-c-${AVRO_C_VERSION}/build && \
+    cd /root/avro-c-${AVRO_C_VERSION}/build && \
+    cmake .. -DCMAKE_INSTALL_PREFIX=/usr/local -DCMAKE_BUILD_TYPE=RelWithDebInfo && \
+    make && make test && make install && cd / && \
+    tar czf avro.tar.gz usr/local/include/avro usr/local/lib/libavro* usr/local/lib/pkgconfig/avro-c.pc
+
+# librdkafka
+RUN curl -o /root/librdkafka-${RDKAFKA_VERSION}.tar.gz -SL https://github.com/edenhill/librdkafka/archive/${RDKAFKA_VERSION}.tar.gz && \
+    echo "${RDKAFKA_SHASUM}" | shasum -a 1 -b -c && \
+    tar -xzf /root/librdkafka-${RDKAFKA_VERSION}.tar.gz -C /root && \
+    cd /root/librdkafka-${RDKAFKA_VERSION} && ./configure && make && make install && cd / && \
+    tar czf librdkafka.tar.gz usr/local/include/librdkafka usr/local/lib/librdkafka*
+
+# Bottled Water
+COPY . /root/bottledwater
+RUN cd /root/bottledwater && \
+    make clean && make && make install && cd / && \
+    tar czf bottledwater-ext-94.tar.gz usr/lib/postgresql/${PG_MAJOR}/lib/bottledwater.so usr/share/postgresql/${PG_MAJOR}/extension/bottledwater* && \
+    cp /root/bottledwater/kafka/bottledwater /root/bottledwater/client/bwtest /usr/local/bin && \
+    tar czf bottledwater-bin.tar.gz usr/local/bin/bottledwater usr/local/bin/bwtest

--- a/build/Dockerfile.postgres94
+++ b/build/Dockerfile.postgres94
@@ -1,0 +1,29 @@
+# Builds a docker image that runs a Postgres server with the Bottled Water
+# plugin installed. Requires that the binaries have been built first (see
+# Dockerfile.build) and placed in the same directory as this Dockerfile.
+#
+# Usage:
+#
+#   (assuming the binaries have been placed into the build/ directory alongside
+#   this Dockerfile)
+#   docker build -f build/Dockerfile.postgres -t confluent/postgres-bw:0.1 build
+#   docker run -d --name postgres confluent/postgres-bw:0.1
+#
+# To connect to the running container with psql:
+#
+#   docker run -it --rm --link postgres postgres:9.5 \
+#     psql -h postgres -U postgres
+#
+# In the psql session, type the following to enable the plugin:
+#
+#   create extension bottledwater;
+
+FROM postgres:9.4
+
+RUN apt-get update && \
+    apt-get install -y libjansson4
+
+ADD bottledwater-ext-94.tar.gz /
+ADD avro.tar.gz /
+RUN cp /usr/local/lib/libavro.so.* /usr/lib/x86_64-linux-gnu/
+COPY replication-config.sh /docker-entrypoint-initdb.d/replication-config.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,12 @@ schema-registry:
     - '48081:8081'
   environment:
     SCHEMA_REGISTRY_AVRO_COMPATIBILITY_LEVEL: none
+postgres-94:
+  build: ./tmp
+  dockerfile: Dockerfile.postgres94
+  hostname: postgres
+  ports:
+    - '45432:5432'
 postgres:
   build: ./tmp
   dockerfile: Dockerfile.postgres
@@ -52,6 +58,7 @@ bottledwater-json:
   extends: {service: bottledwater}
   links:
     - postgres
+    - postgres-94
     - kafka
   environment:
     BOTTLED_WATER_OUTPUT_FORMAT: json
@@ -59,6 +66,7 @@ bottledwater-avro:
   extends: {service: bottledwater}
   links:
     - postgres
+    - postgres-94
     - kafka
     - schema-registry
   environment:

--- a/spec/functional/smoke_spec.rb
+++ b/spec/functional/smoke_spec.rb
@@ -1,9 +1,10 @@
 require 'spec_helper'
 
-shared_examples 'smoke test' do |format|
+shared_examples 'smoke test' do |format, postgres_version|
   before(:context) do
     require 'test_cluster'
     TEST_CLUSTER.bottledwater_format = format
+    TEST_CLUSTER.postgres_version = postgres_version
     TEST_CLUSTER.start
   end
 
@@ -24,10 +25,18 @@ shared_examples 'smoke test' do |format|
   end
 end
 
-describe 'smoke test (JSON)', functional: true, format: :json do
-  it_should_behave_like 'smoke test', :json
+describe 'smoke test (JSON, Postgres 9.4)', functional: true, format: :json, postgres: '9.4' do
+  it_should_behave_like 'smoke test', :json, '9.4'
 end
 
-describe 'smoke test (Avro)', functional: true, format: :avro do
-  it_should_behave_like 'smoke test', :avro
+describe 'smoke test (Avro, Postgres 9.4)', functional: true, format: :avro, postgres: '9.4' do
+  it_should_behave_like 'smoke test', :avro, '9.4'
+end
+
+describe 'smoke test (JSON, Postgres 9.5)', functional: true, format: :json, postgres: '9.5' do
+  it_should_behave_like 'smoke test', :json, '9.5'
+end
+
+describe 'smoke test (Avro, Postgres 9.5)', functional: true, format: :avro, postgres: '9.5' do
+  it_should_behave_like 'smoke test', :avro, '9.5'
 end


### PR DESCRIPTION
This restores minimal test coverage for Postgres 9.4 (after #59 upgraded the build to Postgres 9.5): it ensures that the Docker build will build extensions against both 9.4 and 9.5, and that the smoke test runs against both versions.

This is a rather ugly way of doing it that requires 9.4-specific duplicates of Dockerfile.{build,postgres}, since we need to build the extension for the appropriate version of Postgres.  That also means the
actual test suite does the job of ensuring (some) tests are run for both Postgres versions, rather than just doing a matrix build on Travis.

We could clean this up with Docker build arguments as supported by Docker 1.10+ and Docker Compose 1.6+.  Then we could set the Postgres version in an environment variable and pass it into the Docker build as an argument.

However, that requires [fiddling with the Travis setup](http://graysonkoonce.com/managing-docker-and-docker-compose-versions-on-travis-ci/) to upgrade Docker, and would break the Docker build for anyone using older versions of the Docker tools (including myself).  Therefore punting on that for now. (We'll probably have to do it at some point, since we're starting to get build issues reported with *newer* Docker versions, especially as the Docker images we depend on change to assume new Docker features - see #78, #79, #88.)