### PR TITLE
Fix extension crashes

### DIFF
--- a/ext/oid2avro.c
+++ b/ext/oid2avro.c
@@ -49,6 +49,9 @@ int update_avro_with_char(avro_value_t *output_val, char c);
 int update_avro_with_string(avro_value_t *output_val, Oid typid, Datum pg_datum);
 
 
+static char *make_avro_safe(const char *raw);
+
+
 /* Returns the relation object for the index that we're going to use as key for a
  * particular table. (Indexes are relations too!) Returns null if the table is unkeyed.
  * The return value is opened with a shared lock; call relation_close() when finished. */
@@ -117,7 +120,7 @@ int schema_for_table_key(Relation rel, avro_schema_t *schema_out) {
  * Returns 0 if successful, nonzero if an error occurred generating the schema.
  * If the table is unkeyed, sets *schema_out to NULL and returns 0. */
 int schema_for_table_row(Relation rel, avro_schema_t *schema_out) {
-    char *rel_namespace, *relname;
+    char *rel_namespace, *relname, *relname_avro_safe, *rel_namespace_avro_safe;
     StringInfoData namespace;
     avro_schema_t record_schema, column_schema;
     TupleDesc tupdesc;
@@ -128,12 +131,17 @@ int schema_for_table_row(Relation rel, avro_schema_t *schema_out) {
     initStringInfo(&namespace);
     appendStringInfoString(&namespace, GENERATED_SCHEMA_NAMESPACE);
 
-    /* TODO ensure that names abide by Avro's requirements */
     rel_namespace = get_namespace_name(RelationGetNamespace(rel));
     if (rel_namespace) appendStringInfo(&namespace, ".%s", rel_namespace);
 
+    rel_namespace_avro_safe = make_avro_safe(namespace.data);
+
     relname = RelationGetRelationName(rel);
-    record_schema = avro_schema_record(relname, namespace.data);
+    relname_avro_safe = make_avro_safe(relname);
+
+    record_schema = avro_schema_record(relname_avro_safe, rel_namespace_avro_safe);
+    free(relname_avro_safe);
+    free(rel_namespace_avro_safe);
     if (record_schema == NULL) {
         *schema_out = NULL;
         return EINVAL;
@@ -739,4 +747,54 @@ int update_avro_with_string(avro_value_t *output_val, Oid typid, Datum pg_datum)
     pfree(str);
 
     return err;
+}
+
+
+/* Sanitises the `raw` string to be a valid Avro identifier using an encoding
+ * similar to the "percent encoding" used in URLs.  Unsupported characters are
+ * replaced by a hexadecimal representation:
+ *      e.g. "person.name" -> "person_2e_name"
+ *
+ * Valid Avro identifiers start with [A-Za-z_] and subsequently contain only
+ * [A-Za-z0-9_], as per https://avro.apache.org/docs/1.8.1/spec.html#names
+ *
+ * Returns a malloc'd string which the caller is responsible for freeing.
+ *
+ * N.B.:
+ *  * This encoding is not entirely unambiguous, since:
+ *           "person_2e_name" -> "person_2e_name"
+ *    This could be worked around by treating '_' as an invalid character and
+ *    encoding it too (e.g. "person_2e_name" -> "person_5f_2e_5f_name"), but
+ *    that seems ugly, especially since we ourselves generate names like
+ *    "<relname>_pkey".
+ *  * This function is not Unicode-aware!  Given a string containing (bytes
+ *    representing the encoded form of) non-ASCII characters, it should still
+ *    return a valid Avro identifier, but its behaviour is otherwise
+ *    unspecified.  TODO make it handle Unicode. */
+static char *make_avro_safe(const char *raw) {
+    /* Allocate enough space for the worst case, where we have to encode every
+     * character, requiring 4 bytes per character (_xx_).  This is rather
+     * wasteful in the common case, but we expect this will get freed soon, and
+     * anyway these are unlikely to be very large strings.
+     *
+     * (To be precise, we never need to encode the null terminator byte, and
+     * thus this always wastes at least three bytes.) */
+    char *encoded = malloc(4 * strlen(raw));
+
+    char *pe = encoded;
+    for (const char *p = raw; *p != '\0'; ++p) {
+        const char c = *p;
+        if (
+                (c >= 'A' && c <= 'Z') ||
+                (c >= 'a' && c <= 'z') ||
+                c == '_' ||
+                (c >= '0' && c <= '9' && p != raw)) {
+            *pe++ = c;
+        } else {
+            sprintf(pe, "_%2x_", c);
+            pe += 4;
+        }
+    }
+    *pe = '\0';
+    return encoded;
 }

--- a/ext/oid2avro.h
+++ b/ext/oid2avro.h
@@ -10,8 +10,8 @@
 #define PREDEFINED_SCHEMA_NAMESPACE "com.martinkl.bottledwater.datatypes"
 
 Relation table_key_index(Relation rel);
-avro_schema_t schema_for_table_key(Relation rel);
-avro_schema_t schema_for_table_row(Relation rel);
+int schema_for_table_key(Relation rel, avro_schema_t *schema_out);
+int schema_for_table_row(Relation rel, avro_schema_t *schema_out);
 int tuple_to_avro_row(avro_value_t *output_val, TupleDesc tupdesc, HeapTuple tuple);
 int tuple_to_avro_key(avro_value_t *output_val, TupleDesc tupdesc, HeapTuple tuple,
         Relation rel, Form_pg_index key_index);

--- a/ext/protocol_server.c
+++ b/ext/protocol_server.c
@@ -81,7 +81,9 @@ int update_frame_with_insert(avro_value_t *frame_val, schema_cache_t cache, Rela
     bytea *key_bin = NULL, *new_bin = NULL;
 
     int changed = schema_cache_lookup(cache, rel, &entry);
-    if (changed) {
+    if (changed < 0) {
+        return EINVAL;
+    } else if (changed) {
         check(err, update_frame_with_table_schema(frame_val, entry));
     }
 
@@ -104,7 +106,9 @@ int update_frame_with_update(avro_value_t *frame_val, schema_cache_t cache, Rela
     bytea *old_bin = NULL, *new_bin = NULL, *old_key_bin = NULL, *new_key_bin = NULL;
 
     int changed = schema_cache_lookup(cache, rel, &entry);
-    if (changed) {
+    if (changed < 0) {
+        return EINVAL;
+    } else if (changed) {
         check(err, update_frame_with_table_schema(frame_val, entry));
     }
 
@@ -146,7 +150,9 @@ int update_frame_with_delete(avro_value_t *frame_val, schema_cache_t cache, Rela
     bytea *key_bin = NULL, *old_bin = NULL;
 
     int changed = schema_cache_lookup(cache, rel, &entry);
-    if (changed) {
+    if (changed < 0) {
+        return EINVAL;
+    } else if (changed) {
         check(err, update_frame_with_table_schema(frame_val, entry));
     }
 

--- a/ext/schema_cache.c
+++ b/ext/schema_cache.c
@@ -117,10 +117,12 @@ int schema_cache_entry_update(schema_cache_t cache, schema_cache_entry *entry, R
     err = schema_for_table_row(rel, &entry->row_schema);
     if (err) return err;
     entry->row_iface = avro_generic_class_from_schema(entry->row_schema);
+    if (entry->row_iface == NULL) return EINVAL;
     avro_generic_value_new(entry->row_iface, &entry->row_value);
 
     if (entry->key_schema) {
         entry->key_iface = avro_generic_class_from_schema(entry->key_schema);
+        if (entry->key_iface == NULL) return EINVAL;
         avro_generic_value_new(entry->key_iface, &entry->key_value);
     }
 

--- a/ext/schema_cache.c
+++ b/ext/schema_cache.c
@@ -6,7 +6,7 @@
 #include "access/tupdesc.h"
 #include "utils/lsyscache.h"
 
-void schema_cache_entry_update(schema_cache_t cache, schema_cache_entry *entry, Relation rel);
+int schema_cache_entry_update(schema_cache_t cache, schema_cache_entry *entry, Relation rel);
 bool schema_cache_entry_changed(schema_cache_entry *entry, Relation rel);
 void schema_cache_entry_decrefs(schema_cache_entry *entry);
 void tupdesc_debug_info(StringInfo msg, TupleDesc tupdesc);
@@ -41,10 +41,12 @@ schema_cache_t schema_cache_new(MemoryContext context) {
 
 /* Obtains the schema cache entry for the given relation, creating or updating it if necessary.
  * If the schema hasn't changed since the last invocation, a cached value is used and 0 is returned.
- * If the schema has changed, 1 is returned. If the schema has not been seen before, 2 is returned. */
+ * If the schema has changed, 1 is returned. If the schema has not been seen before, 2 is returned.
+ * If an error occurred creating or updating the entry, returns a negative value. */
 int schema_cache_lookup(schema_cache_t cache, Relation rel, schema_cache_entry **entry_out) {
     Oid relid = RelationGetRelid(rel);
     bool found_entry;
+    int err;
     schema_cache_entry *entry = (schema_cache_entry *)
         hash_search(cache->entries, &relid, HASH_ENTER, &found_entry);
 
@@ -57,22 +59,31 @@ int schema_cache_lookup(schema_cache_t cache, Relation rel, schema_cache_entry *
         } else {
             /* Schema has changed since we last saw it -- update the cache */
             schema_cache_entry_decrefs(entry);
-            schema_cache_entry_update(cache, entry, rel);
+            err = schema_cache_entry_update(cache, entry, rel);
+            if (err) {
+                *entry_out = NULL;
+                return -1;
+            }
             *entry_out = entry;
             return 1;
         }
     } else {
         /* Schema not previously seen -- populate a new cache entry */
-        schema_cache_entry_update(cache, entry, rel);
+        err = schema_cache_entry_update(cache, entry, rel);
+        if (err) {
+            *entry_out = NULL;
+            return -2;
+        }
         *entry_out = entry;
         return 2;
     }
 }
 
 /* Populates a schema cache entry with the information from a given table. */
-void schema_cache_entry_update(schema_cache_t cache, schema_cache_entry *entry, Relation rel) {
+int schema_cache_entry_update(schema_cache_t cache, schema_cache_entry *entry, Relation rel) {
     Relation index_rel;
     MemoryContext oldctx;
+    int err;
 
     entry->relid = RelationGetRelid(rel);
     entry->ns_id = RelationGetNamespace(rel);
@@ -101,8 +112,10 @@ void schema_cache_entry_update(schema_cache_t cache, schema_cache_entry *entry, 
     entry->row_tupdesc = CreateTupleDescCopyConstr(RelationGetDescr(rel));
     MemoryContextSwitchTo(oldctx);
 
-    entry->key_schema = schema_for_table_key(rel);
-    entry->row_schema = schema_for_table_row(rel);
+    err = schema_for_table_key(rel, &entry->key_schema);
+    if (err) return err;
+    err = schema_for_table_row(rel, &entry->row_schema);
+    if (err) return err;
     entry->row_iface = avro_generic_class_from_schema(entry->row_schema);
     avro_generic_value_new(entry->row_iface, &entry->row_value);
 
@@ -110,6 +123,8 @@ void schema_cache_entry_update(schema_cache_t cache, schema_cache_entry *entry, 
         entry->key_iface = avro_generic_class_from_schema(entry->key_schema);
         avro_generic_value_new(entry->key_iface, &entry->key_value);
     }
+
+    return 0;
 }
 
 /* Returns false if the schema of the given relation matches the cache entry,

--- a/ext/snapshot.c
+++ b/ext/snapshot.c
@@ -351,12 +351,16 @@ bytea *schema_for_relname(char *relname, bool get_key) {
     Relation rel = relation_openrv(relvar, AccessShareLock);
 
     if (get_key) {
-        schema = schema_for_table_key(rel);
+        err = schema_for_table_key(rel, &schema);
     } else {
-        schema = schema_for_table_row(rel);
+        err = schema_for_table_row(rel, &schema);
     }
 
     relation_close(rel, AccessShareLock);
+    if (err) {
+        elog(ERROR, "bottledwater_table_schema: Could not get schema for relname %s: %s",
+                relname, avro_strerror());
+    }
     if (!schema) return NULL;
 
     err = try_writing(&json, &write_schema_json, schema);

--- a/spec/functional/schema_spec.rb
+++ b/spec/functional/schema_spec.rb
@@ -445,7 +445,7 @@ shared_examples 'database schema support' do |format|
     end
 
     example 'if you remove all columns from a table, publishes dummy messages' do
-      xbug 'dropping columns seems to do weird stuff'
+      known_bug 'terminates replication stream', 'https://github.com/confluentinc/bottledwater-pg/issues/97'
 
       table_name = 'zero_columns_eventually'
 

--- a/spec/functional/schema_spec.rb
+++ b/spec/functional/schema_spec.rb
@@ -353,6 +353,32 @@ shared_examples 'database schema support' do |format|
   end
 
 
+  describe 'column names' do
+    example 'supports column names up to Postgres max identifier length in row' do
+      long_name = 'z' * postgres_max_identifier_length
+
+      message = retrieve_roundtrip_message(
+          'int', 42,
+          table_name: :test_long_name_value, column_name: long_name)
+
+      value = decode_value(message.value)
+      expect(value).to have_key(long_name)
+    end
+
+    example 'supports column names up to Postgres max identifier length in key' do
+      long_name = 'z' * postgres_max_identifier_length
+
+      message = retrieve_roundtrip_message(
+          'int', 42,
+          as_key: true,
+          table_name: :test_long_name_key, column_name: long_name)
+
+      key = decode_key(message.key)
+      expect(key).to have_key(long_name)
+    end
+  end
+
+
   describe 'table with no columns' do
     after(:example) do
       # this is known to crash Postgres

--- a/spec/functional/topic_spec.rb
+++ b/spec/functional/topic_spec.rb
@@ -39,7 +39,7 @@ describe 'topics', functional: true do
       expect(kazoo.topics).to have_key('things')
     end
 
-    example 'creating a table with a silly name creates a topic based on the sanitised name' do
+    example 'table names with non-alphanumeric characters create a topic based on the sanitised name' do
       known_bug 'crashes Postgres', 'https://github.com/confluentinc/bottledwater-pg/issues/64'
 
       silly_name = 'flobble-biscuits?whatisthetime/hahahaha'
@@ -48,7 +48,7 @@ describe 'topics', functional: true do
       postgres.exec %(INSERT INTO "#{silly_name}" DEFAULT VALUES)
       sleep 1
 
-      expect(kazoo.topics).to include(match(/flobble/))
+      expect(kazoo.topics).to include(match(/flobble.*biscuits.*whatisthetime.*hahahaha/))
     end
 
     example 'supports table names up to Postgres max identifier length' do

--- a/spec/functional/topic_spec.rb
+++ b/spec/functional/topic_spec.rb
@@ -50,6 +50,16 @@ describe 'topics', functional: true do
 
       expect(kazoo.topics).to include(match(/flobble/))
     end
+
+    example 'supports table names up to Postgres max identifier length' do
+      long_name = 'z' * postgres_max_identifier_length
+
+      postgres.exec %(CREATE TABLE "#{long_name}" (thing SERIAL NOT NULL PRIMARY KEY))
+      postgres.exec %(INSERT INTO "#{long_name}" DEFAULT VALUES)
+      sleep 1
+
+      expect(kazoo.topics).to include(long_name)
+    end
   end
 
   describe "with topic autocreate disabled and --on-error=exit" do

--- a/spec/functional/topic_spec.rb
+++ b/spec/functional/topic_spec.rb
@@ -40,8 +40,6 @@ describe 'topics', functional: true do
     end
 
     example 'table names with non-alphanumeric characters create a topic based on the sanitised name' do
-      known_bug 'crashes Postgres', 'https://github.com/confluentinc/bottledwater-pg/issues/64'
-
       silly_name = 'flobble-biscuits?whatisthetime/hahahaha'
 
       postgres.exec %(CREATE TABLE "#{silly_name}" (thing SERIAL NOT NULL PRIMARY KEY))

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,10 +20,19 @@ module KnownBugs
   end
 end
 
+module Constants
+  # Need to define methods rather than just regular constants, because
+  # apparently RSpec's `config.include` doesn't include constants.
+
+  # see https://www.postgresql.org/docs/current/static/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS
+  def postgres_max_identifier_length; 63; end
+end
+
 RSpec.configure do |config|
   config.include StringLogger
   config.include KnownBugs
   config.include KafkaHelpers
+  config.include Constants
 
   config.around(:example) do |example|
     example.run


### PR DESCRIPTION
This fixes two known cases that segfault the Bottled Water extension (and thus cause Postgres to restart all backends):

* Non-alphanumeric characters in table names or column names (#53, #64) due to Avro having stricter restrictions on identifiers than Postgres
* Tables containing no columns (#61) due to avro-c blowing up on zero-field record schemas

Both were segfaulting due to not checking the return values of Avro library functions.

I also added tests for long table/column names - it turns out Postgres already has a [compile-time limit on identifier length](https://www.postgresql.org/docs/current/static/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS), so unless people are routinely patching Postgres to increase the limit, we probably don't need to handle this case.

For invalid Avro identifiers, I chose to sanitise identifiers using an encoding similar to the "percent encoding" used in URLs.  [Unsupported characters](https://avro.apache.org/docs/1.8.1/spec.html#names) are replaced by a hexadecimal representation: e.g. "person.name" -> "person_2e_name"

A couple of gotchas:
 * This encoding is not entirely unambiguous, since:
          "person_2e_name" -> "person_2e_name".
   This could be worked around by treating '_' as an invalid character and encoding it too (e.g. "person_2e_name" -> "person_5f_2e_5f_name"), but that seems ugly, especially since we ourselves generate names like "<relname>_pkey".
 * This encoding is not Unicode-aware!  Given a string containing (bytes representing the encoded form of) non-ASCII characters, it should still return a valid Avro identifier, but its behaviour is otherwise unspecified.

For tables with no columns, ideally we'd represent this by just publishing Avro records with no fields, but that was the existing behaviour of the code, and Avro was bailing out when trying to process the record schema.  I'm not sure (and the spec doesn't make it clear) whether a record with zero fields is valid Avro, but it's at least not supported by avro-c at present.  So instead I just publish a "dummy" field with the value `false`.