### PR TITLE
Bring getting started instructions up to date

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,10 +69,12 @@ First, install:
   orchestrate the interaction between services.
 
 After the prerequisite applications are installed, you need to build the Docker containers for Bottled Water and Postgres by running `make docker-compose`.
-As soon as the build process finishes, start up Postgres, Kafka, Zookeeper (required by Kafka) and the [Confluent schema registry](http://confluent.io/docs/current/schema-registry/docs/intro.html)
-by running `docker-compose` as follows:
+As soon as the build process finishes, start up Postgres, Kafka and the
+[Confluent schema
+registry](http://confluent.io/docs/current/schema-registry/docs/intro.html) by
+running `docker-compose` as follows:
 
-    $ docker-compose up -d zookeeper kafka schema-registry postgres
+    $ docker-compose up -d kafka schema-registry postgres
 
 The `postgres-bw` image extends the
 [official Postgres docker image](https://registry.hub.docker.com/_/postgres/) and adds

--- a/README.md
+++ b/README.md
@@ -68,12 +68,18 @@ First, install:
 * [docker-compose](https://docs.docker.com/compose/install/), which is used to
   orchestrate the interaction between services.
 
-After the prerequisite applications are installed, you need to build the Docker containers for Bottled Water and Postgres by running `make docker-compose`.
-As soon as the build process finishes, start up Postgres, Kafka and the
-[Confluent schema
+After the prerequisite applications are installed, you need to build the Docker containers for Bottled Water and Postgres:
+
+    $ make docker-compose
+
+Once the build process finishes, set up some required environment variables,
+then start up Postgres, Kafka and the [Confluent schema
 registry](http://confluent.io/docs/current/schema-registry/docs/intro.html) by
 running `docker-compose` as follows:
 
+    $ export KAFKA_ADVERTISED_HOST_NAME=$(docker run --rm debian:jessie ip route | awk '/^default via / { print $3 }') \
+             KAFKA_LOG_CLEANUP_POLICY=compact \
+             KAFKA_AUTO_CREATE_TOPICS_ENABLE=true
     $ docker-compose up -d kafka schema-registry postgres
 
 The `postgres-bw` image extends the

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,16 @@
-# N.B. assumes you have set the environment variable
-# KAFKA_ADVERTISED_HOST_NAME, in the environment of the host where you are
-# running docker-compose, to the IP address of the Docker host.
+# N.B. assumes you have set the following environment variables in the
+# environment of the host where you are running docker-compose:
 #
-# You can determine the Docker host IP with a command like:
+# * KAFKA_ADVERTISED_HOST_NAME: set to the IP address of the Docker host
+#   (see below).
+#
+# * KAFKA_LOG_CLEANUP_POLICY: "delete" or "compact" (see log.cleanup.policy in
+#   the Kafka docs)
+#
+# * KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true" or "false" (see
+#   auto.create.topics.enable in the Kafka docs)
+#
+# You can determine the IP address of the Docker host with a command like:
 #
 #   docker run --rm debian:latest ip route | awk '/^default via / { print $3 }'
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,13 +45,13 @@ postgres-94:
   dockerfile: Dockerfile.postgres94
   hostname: postgres
   ports:
-    - '45432:5432'
+    - '54094:5432'
 postgres:
   build: ./tmp
   dockerfile: Dockerfile.postgres
   hostname: postgres
   ports:
-    - '45432:5432'
+    - '54095:5432'
 bottledwater:
   build: ./tmp
   dockerfile: Dockerfile.client


### PR DESCRIPTION
Recent work on the automation harness for the [test suite](https://github.com/confluentinc/bottledwater-pg/pull/63), which scripts the Docker Compose setup, introduced changes to that setup which broke more normal, manual use cases, including those documented in the ["getting started"](https://github.com/confluentinc/bottledwater-pg/blob/76f1fac284bb94578d794a05663fc0ec4710d8ba/README.md#running-in-docker) portion of the README.

The first change that caused trouble was introducing passthrough of certain `KAFKA_*` environment variables respected by the Kafka container.  These allow customising the Kafka config, e.g. to enable or disable topic autocreate.  Unfortunately, this results in *requiring* those environment variables to be set in the host environment before running `docker-compose`:
 * Docker Compose defaults to the empty string for a passed-through environment variable if it is unset on the host;
 * the Kafka startup script does not filter out environment variables that are present but set to the empty string (unlike our own bottledwater-docker-wrapper.sh which [handles this case specially](https://github.com/confluentinc/bottledwater-pg/blob/76f1fac284bb94578d794a05663fc0ec4710d8ba/build/bottledwater-docker-wrapper.sh#L15-L17));
 * Kafka does not expect the corresponding config properties to be set to the empty string, so it fails on startup.

As an inadequate workaround, this PR explicitly documents those variables in the README.  (While  this makes getting started a little harder and more arcane, it does have the side benefit of potentially educating new users about those Kafka config settings, which are after all used in the tests because they have a large impact on the semantics of Bottled Water.)

The second change was adding a second Postgres service running Postgres 9.4, and making the Bottled Water services depend on both.  This is done for the Docker Compose "links" feature, so that the Bottled Water container can address whichever Postgres is running simply by the hostname "postgres".  This works fine in the tests, which run `docker-compose up --no-deps [service]` and explicitly start just one of the Postgressen, but on the command line a simple `docker-compose up bottledwater-json` will attempt to start both, and fail because they attempt to bind the same host port.

To work around this, this PR assigns different host ports to each Postgres service, so they no longer clash.  This still means you'll end up redundantly running one more Postgres than you actually wanted, but that should be fairly harmless.

Now that Travis has upgraded the versions of Docker and Docker Compose in their environment, I'm hoping we can remove some of this cruft by taking advantage of features in those newer versions.  Also I'm considering replacing the tests' use of Docker Compose with a custom orchestration layer, which would let us work around these problems.  So this PR is an interim solution.