### PR TITLE
Check for memory leaks during CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ install:
 script:
   - make -j5 docker-compose
   - make test 2>make-test.err
+  # We log VALGRIND_ERROR if Valgrind detected any errors during the tests;
+  # see check_valgrind_errors in spec/test_cluster.rb
   - '! grep VALGRIND_ERROR make-test.err'
 after_failure:
   - "echo Tests failed, stderr was:"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ install:
 script:
   - make -j5 docker-compose
   - make test 2>make-test.err
+  - '! grep VALGRIND_ERROR make-test.err'
 after_failure:
   - "echo Tests failed, stderr was:"
   - cat make-test.err

--- a/build/Dockerfile.client
+++ b/build/Dockerfile.client
@@ -13,7 +13,7 @@ FROM postgres:9.5
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
-        libcurl3 libjansson4 libpq5
+        libcurl3 libjansson4 libpq5 valgrind
 
 ADD avro.tar.gz /
 ADD librdkafka.tar.gz /

--- a/build/bottledwater-docker-wrapper.sh
+++ b/build/bottledwater-docker-wrapper.sh
@@ -39,5 +39,12 @@ if getent hosts schema-registry >/dev/null; then
 fi
 
 BOTTLEDWATER=/usr/local/bin/bottledwater
-log "Running: $BOTTLEDWATER ${bw_opts[@]} $@"
-exec "$BOTTLEDWATER" "${bw_opts[@]}" "$@"
+VALGRIND=/usr/bin/valgrind
+
+if [[ -n $VALGRIND_ENABLED ]]; then
+  log "Running: $VALGRIND $VALGRIND_OPTS $BOTTLEDWATER ${bw_opts[@]} $@"
+  exec "$VALGRIND" $VALGRIND_OPTS "$BOTTLEDWATER" "${bw_opts[@]}" "$@"
+else
+  log "Running: $BOTTLEDWATER ${bw_opts[@]} $@"
+  exec "$BOTTLEDWATER" "${bw_opts[@]}" "$@"
+fi

--- a/client/connect.c
+++ b/client/connect.c
@@ -46,6 +46,11 @@ client_context_t db_client_new() {
 void db_client_free(client_context_t context) {
     client_sql_disconnect(context);
     if (context->repl.conn) PQfinish(context->repl.conn);
+    if (context->repl.snapshot_name) free(context->repl.snapshot_name);
+    if (context->repl.output_plugin) free(context->repl.output_plugin);
+    if (context->repl.slot_name) free(context->repl.slot_name);
+    if (context->app_name) free(context->app_name);
+    if (context->conninfo) free(context->conninfo);
     free(context);
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,6 +64,8 @@ bottledwater:
     BOTTLED_WATER_ON_ERROR:
     BOTTLED_WATER_SKIP_SNAPSHOT:
     BOTTLED_WATER_TOPIC_PREFIX:
+    VALGRIND_ENABLED:
+    VALGRIND_OPTS:
 bottledwater-json:
   extends: {service: bottledwater}
   links:

--- a/kafka/bottledwater.c
+++ b/kafka/bottledwater.c
@@ -738,10 +738,10 @@ client_context_t init_client() {
     frame_reader->on_error        = on_client_error;
 
     client_context_t client = db_client_new();
-    client->app_name = APP_NAME;
+    client->app_name = strdup(APP_NAME);
     client->allow_unkeyed = false;
-    client->repl.slot_name = DEFAULT_REPLICATION_SLOT;
-    client->repl.output_plugin = OUTPUT_PLUGIN;
+    client->repl.slot_name = strdup(DEFAULT_REPLICATION_SLOT);
+    client->repl.output_plugin = strdup(OUTPUT_PLUGIN);
     client->repl.frame_reader = frame_reader;
     return client;
 }

--- a/spec/functional/message_spec.rb
+++ b/spec/functional/message_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'format_contexts'
 require 'test_cluster'
 
-shared_examples 'publishing messages' do |format, postgres_version|
+shared_examples 'publishing messages' do |format, postgres_version, valgrind|
   # We only stop the cluster after all examples in the context have run, so
   # state in Postgres, Kafka and Bottled Water can leak between examples.  We
   # therefore need to make sure examples look at different tables, so they
@@ -14,6 +14,7 @@ shared_examples 'publishing messages' do |format, postgres_version|
     before(:context) do
       TEST_CLUSTER.bottledwater_format = format
       TEST_CLUSTER.postgres_version = postgres_version
+      TEST_CLUSTER.valgrind = valgrind
 
       TEST_CLUSTER.before_service(TEST_CLUSTER.bottledwater_service, 'Prepopulating users table') do |cluster|
         cluster.postgres.exec('CREATE TABLE users (id SERIAL PRIMARY KEY, username TEXT)')
@@ -99,6 +100,7 @@ shared_examples 'publishing messages' do |format, postgres_version|
     before(:context) do
       TEST_CLUSTER.bottledwater_format = format
       TEST_CLUSTER.postgres_version = postgres_version
+      TEST_CLUSTER.valgrind = valgrind
 
       # Kafka 0.9 rejects unkeyed messages sent to a compacted table, but we
       # set compaction as default in test_cluster.rb, so we need to explicitly
@@ -163,17 +165,25 @@ end
 
 
 describe 'publishing messages (JSON, Postgres 9.4)', functional: true, format: :json, postgres: '9.4' do
-  include_examples 'publishing messages', :json, '9.4'
+  include_examples 'publishing messages', :json, '9.4', false
 end
 
 describe 'publishing messages (Avro, Postgres 9.4)', functional: true, format: :avro, postgres: '9.4' do
-  include_examples 'publishing messages', :avro, '9.4'
+  include_examples 'publishing messages', :avro, '9.4', false
 end
 
 describe 'publishing messages (JSON, Postgres 9.5)', functional: true, format: :json, postgres: '9.5' do
-  include_examples 'publishing messages', :json, '9.5'
+  include_examples 'publishing messages', :json, '9.5', false
 end
 
 describe 'publishing messages (Avro, Postgres 9.5)', functional: true, format: :avro, postgres: '9.5' do
-  include_examples 'publishing messages', :avro, '9.5'
+  include_examples 'publishing messages', :avro, '9.5', false
+end
+
+describe 'publishing messages (JSON, Valgrind)', functional: true, format: :json, postgres: '9.5', valgrind: true do
+  include_examples 'publishing messages', :json, '9.5', true
+end
+
+describe 'publishing messages (Avro, Valgrind)', functional: true, format: :avro, postgres: '9.5', valgrind: true do
+  include_examples 'publishing messages', :avro, '9.5', true
 end


### PR DESCRIPTION
This PR:

1. Adds support to the BW Docker image for running the BW client under [Valgrind](http://valgrind.org/) if the environment variable VALGRIND_ENABLED is set;
2. Runs the core functionality tests under Valgrind as part of the CI build on Travis.
3. Fixes a couple of harmless memory leaks, so that Valgrind reports no errors at time of PR submission.

This means any subsequent commits and PRs to the client daemon will get automatically checked for memory leaks.

I haven't yet looked into Valgrinding the Postgres extension; I expect that to be trickier, because of the custom `palloc` allocator used there, and because it runs inside a forked child of Postgres rather than a standalone executable.