### PR TITLE
Unbreak build if Avro is older than 1.8

### DIFF
--- a/kafka/Makefile
+++ b/kafka/Makefile
@@ -6,7 +6,8 @@ PG_CFLAGS = -I$(shell pg_config --includedir) -I$(shell pg_config --includedir-s
 PG_LDFLAGS = -L$(shell pg_config --libdir) -lpq
 KAFKA_CFLAGS =
 KAFKA_LDFLAGS = -lrdkafka -lz -lpthread # TODO -lrt needed on Linux for clock_gettime, but not on OSX?
-AVRO_CFLAGS = $(shell pkg-config --cflags avro-c)
+AVRO_1_8 = $(shell pkg-config --atleast-version=1.8.0 avro-c && echo -DAVRO_1_8)
+AVRO_CFLAGS = $(shell pkg-config --cflags avro-c) $(AVRO_1_8)
 AVRO_LDFLAGS = $(shell pkg-config --libs avro-c)
 CURL_CFLAGS = $(shell curl-config --cflags)
 CURL_LDFLAGS = $(shell curl-config --libs)

--- a/kafka/bottledwater.c
+++ b/kafka/bottledwater.c
@@ -379,8 +379,13 @@ char* topic_name_from_avro_schema(avro_schema_t schema) {
 
     const char *table_name = avro_schema_name(schema);
 
+#ifdef AVRO_1_8
     /* Gets the avro schema namespace which contains the Postgres schema name */
     const char *namespace = avro_schema_namespace(schema);
+#else
+#warning "avro-c older than 1.8.0, will not include Postgres schema in Kafka topic name"
+    const char namespace[] = "dummy";
+#endif
 
     char topic_name[TABLE_NAME_BUFFER_LENGTH];
     /* Strips the beginning part of the namespace to extract the Postgres schema name


### PR DESCRIPTION
PR #102 added a call to `avro_schema_namespace` in order to include the Postgres schema name (which we transport via the Avro schema namespace) in the generated Kafka topic for a table.

Unfortunately, `avro_schema_namespace` was [added somewhat recently](https://github.com/apache/avro/commit/7f2afa8df4167435f4e92c715d65519d01bda2f8) to avro-c and is not present in avro-c releases before 1.8.0.

Since packages are hard to come by for Avro 1.8.0+, this PR restores compatibility with Avro 1.7 (dropping the schema from the topic name in that case, and generating a build warning).  /cc @mcapitanio 

Tested with avro-c 1.8.0 (as [downloaded by Dockerfile.build](https://github.com/confluentinc/bottledwater-pg/blob/86e19f7e9bf0fd7d3620b19133ad69438c704702/build/Dockerfile.build#L17-L18)) and 1.7.7.