### PR TITLE
Support arbitrary-precision numbers #4

### DIFF
--- a/ext/oid2avro.c
+++ b/ext/oid2avro.c
@@ -289,10 +289,7 @@ avro_schema_t schema_for_oid(predef_schema *predef, Oid typid) {
             value_schema = avro_schema_long();
             break;
         case NUMERICOID: /* numeric(p, s), decimal(p, s): arbitrary precision number */
-            /* There is no implementation for Decimal type in apache/avro package for c language.
-             * We use logic for "double" type to avoid "0.0" values.
-             */
-            value_schema = avro_schema_double();
+            value_schema = schema_for_numeric(predef);
             break;
 
         /* Date/time types. We don't bother with abstime, reltime and tinterval (which are based

--- a/ext/oid2avro.c
+++ b/ext/oid2avro.c
@@ -290,7 +290,7 @@ avro_schema_t schema_for_oid(predef_schema *predef, Oid typid) {
             break;
         case NUMERICOID: /* numeric(p, s), decimal(p, s): arbitrary precision number */
             /* There is no implementation for Decimal type in apache/avro package for c language.
-             * We use logic for "double" type ti avoid "0.0" values.
+             * We use logic for "double" type to avoid "0.0" values.
              */
             value_schema = avro_schema_double();
             break;
@@ -411,7 +411,7 @@ int update_avro_with_datum(avro_value_t *output_val, Oid typid, Datum pg_datum) 
             break;
         case NUMERICOID:
             /* There is no implementation for Decimal type in apache/avro package for c language.
-             * We use logic for "double" type ti avoid "0.0" values.
+             * We use logic for "double" type to avoid "0.0" values.
              */
             check(err, avro_value_set_double(&branch_val, atof(numeric_normalize(DatumGetNumeric(pg_datum)))));
             break;

--- a/ext/oid2avro.c
+++ b/ext/oid2avro.c
@@ -289,7 +289,10 @@ avro_schema_t schema_for_oid(predef_schema *predef, Oid typid) {
             value_schema = avro_schema_long();
             break;
         case NUMERICOID: /* numeric(p, s), decimal(p, s): arbitrary precision number */
-            value_schema = schema_for_numeric(predef);
+            /* There is no implementation for Decimal type in apache/avro package for c language.
+             * We use logic for "double" type ti avoid "0.0" values.
+             */
+            value_schema = avro_schema_double();
             break;
 
         /* Date/time types. We don't bother with abstime, reltime and tinterval (which are based
@@ -407,7 +410,10 @@ int update_avro_with_datum(avro_value_t *output_val, Oid typid, Datum pg_datum) 
             check(err, avro_value_set_long(&branch_val, DatumGetCommandId(pg_datum)));
             break;
         case NUMERICOID:
-            DatumGetNumeric(pg_datum); // TODO
+            /* There is no implementation for Decimal type in apache/avro package for c language.
+             * We use logic for "double" type ti avoid "0.0" values.
+             */
+            check(err, avro_value_set_double(&branch_val, atof(numeric_normalize(DatumGetNumeric(pg_datum)))));
             break;
         case DATEOID:
             check(err, update_avro_with_date(output_val, DatumGetDateADT(pg_datum)));

--- a/spec/bin/generate_type_specs.rb
+++ b/spec/bin/generate_type_specs.rb
@@ -130,7 +130,6 @@ INTERNAL_TYPES = Set[*%w(
 # in the form of a Github issue
 KNOWN_BUGS = {
   'money' => ['multiplied by 100', 'https://github.com/confluentinc/bottledwater-pg/issues/60'],
-  'numeric' => ['replaced by zero', 'https://github.com/confluentinc/bottledwater-pg/issues/4'],
 }
 
 # only use this list during development, otherwise file an issue!


### PR DESCRIPTION
We could use logic for "double" type ti avoid "0.0" values.
It is not full support for Decimal type, but it is useful for most cases.