### PR TITLE
Pass client error policy down to snapshot and output plugin

### DIFF
--- a/client/connect.c
+++ b/client/connect.c
@@ -333,12 +333,16 @@ int snapshot_start(client_context_t context) {
     check(err, exec_sql(context, query->data));
     destroyPQExpBuffer(query);
 
-    Oid argtypes[] = { 25, 16 }; // 25 == TEXTOID, 16 == BOOLOID
-    const char *args[] = { "%", context->allow_unkeyed ? "t" : "f" };
+    Oid argtypes[] = { 25, 16, 25 }; // 25 == TEXTOID, 16 == BOOLOID
+    const char *args[] = {
+        "%",
+        context->allow_unkeyed ? "t" : "f",
+        context->error_policy
+    };
 
     if (!PQsendQueryParams(context->sql_conn,
-                "SELECT bottledwater_export(table_pattern := $1, allow_unkeyed := $2)",
-                2, argtypes, args, NULL, NULL, 1)) { // The final 1 requests results in binary format
+                "SELECT bottledwater_export(table_pattern := $1, allow_unkeyed := $2, error_policy := $3)",
+                3, argtypes, args, NULL, NULL, 1)) { // The final 1 requests results in binary format
         client_error(context, "Could not dispatch snapshot fetch: %s",
                 PQerrorMessage(context->sql_conn));
         return EIO;

--- a/client/connect.h
+++ b/client/connect.h
@@ -7,6 +7,7 @@
 
 typedef struct {
     char *conninfo, *app_name;
+    char *error_policy;
     PGconn *sql_conn;
     replication_stream repl;
     bool allow_unkeyed;
@@ -21,6 +22,7 @@ typedef client_context *client_context_t;
 
 client_context_t db_client_new(void);
 void db_client_free(client_context_t context);
+void db_client_set_error_policy(client_context_t context, const char *policy);
 int db_client_start(client_context_t context);
 int db_client_poll(client_context_t context);
 int db_client_wait(client_context_t context);

--- a/client/replication.c
+++ b/client/replication.c
@@ -145,9 +145,10 @@ int replication_stream_check(replication_stream_t stream) {
  * starting from position stream->start_lsn. */
 int replication_stream_start(replication_stream_t stream) {
     PQExpBuffer query = createPQExpBuffer();
-    appendPQExpBuffer(query, "START_REPLICATION SLOT \"%s\" LOGICAL %X/%X",
+    appendPQExpBuffer(query, "START_REPLICATION SLOT \"%s\" LOGICAL %X/%X (error_policy '%s')",
             stream->slot_name,
-            (uint32) (stream->start_lsn >> 32), (uint32) stream->start_lsn);
+            (uint32) (stream->start_lsn >> 32), (uint32) stream->start_lsn,
+            "log");
 
     PGresult *res = PQexec(stream->conn, query->data);
 

--- a/client/replication.c
+++ b/client/replication.c
@@ -143,12 +143,12 @@ int replication_stream_check(replication_stream_t stream) {
 
 /* Starts streaming logical changes from replication slot stream->slot_name,
  * starting from position stream->start_lsn. */
-int replication_stream_start(replication_stream_t stream) {
+int replication_stream_start(replication_stream_t stream, const char *error_policy) {
     PQExpBuffer query = createPQExpBuffer();
     appendPQExpBuffer(query, "START_REPLICATION SLOT \"%s\" LOGICAL %X/%X (error_policy '%s')",
             stream->slot_name,
             (uint32) (stream->start_lsn >> 32), (uint32) stream->start_lsn,
-            "log");
+            error_policy);
 
     PGresult *res = PQexec(stream->conn, query->data);
 

--- a/client/replication.c
+++ b/client/replication.c
@@ -145,7 +145,7 @@ int replication_stream_check(replication_stream_t stream) {
  * starting from position stream->start_lsn. */
 int replication_stream_start(replication_stream_t stream, const char *error_policy) {
     PQExpBuffer query = createPQExpBuffer();
-    appendPQExpBuffer(query, "START_REPLICATION SLOT \"%s\" LOGICAL %X/%X (error_policy '%s')",
+    appendPQExpBuffer(query, "START_REPLICATION SLOT \"%s\" LOGICAL %X/%X (\"error_policy\" '%s')",
             stream->slot_name,
             (uint32) (stream->start_lsn >> 32), (uint32) stream->start_lsn,
             error_policy);

--- a/client/replication.h
+++ b/client/replication.h
@@ -26,7 +26,7 @@ typedef replication_stream *replication_stream_t;
 int replication_slot_create(replication_stream_t stream);
 int replication_slot_drop(replication_stream_t stream);
 int replication_stream_check(replication_stream_t stream);
-int replication_stream_start(replication_stream_t stream);
+int replication_stream_start(replication_stream_t stream, const char *error_policy);
 int replication_stream_poll(replication_stream_t stream);
 int replication_stream_keepalive(replication_stream_t stream);
 

--- a/ext/Makefile
+++ b/ext/Makefile
@@ -7,7 +7,7 @@ AVRO_LDFLAGS = $(shell pkg-config --libs avro-c)
 PG_CPPFLAGS += $(AVRO_CFLAGS) -std=c99
 SHLIB_LINK += $(AVRO_LDFLAGS)
 
-OBJS = io_util.o logdecoder.o oid2avro.o schema_cache.o protocol.o protocol_server.o snapshot.o
+OBJS = io_util.o error_policy.o logdecoder.o oid2avro.o schema_cache.o protocol.o protocol_server.o snapshot.o
 DATA = bottledwater--0.1.sql
 
 PG_CONFIG = pg_config

--- a/ext/bottledwater--0.1.sql
+++ b/ext/bottledwater--0.1.sql
@@ -10,8 +10,17 @@ CREATE OR REPLACE FUNCTION bottledwater_row_schema(name) RETURNS text
 CREATE OR REPLACE FUNCTION bottledwater_frame_schema() RETURNS text
     AS 'bottledwater', 'bottledwater_frame_schema' LANGUAGE C VOLATILE STRICT;
 
+DROP DOMAIN IF EXISTS bottledwater_error_policy;
+CREATE DOMAIN bottledwater_error_policy AS text
+    CONSTRAINT bottledwater_error_policy_valid CHECK (VALUE IN (
+        -- these values should match the constants defined in protocol.h
+        'log',
+        'exit'
+    ));
+
 CREATE OR REPLACE FUNCTION bottledwater_export(
         table_pattern text    DEFAULT '%',
-        allow_unkeyed boolean DEFAULT false
+        allow_unkeyed boolean DEFAULT false,
+        error_policy bottledwater_error_policy DEFAULT 'exit'
     ) RETURNS setof bytea
     AS 'bottledwater', 'bottledwater_export' LANGUAGE C VOLATILE STRICT;

--- a/ext/error_policy.c
+++ b/ext/error_policy.c
@@ -1,0 +1,26 @@
+#include "error_policy.h"
+#include "protocol.h"
+
+#include <string.h>
+#include "postgres.h"
+
+error_policy_t parse_error_policy(const char *str) {
+    if (strcmp(PROTOCOL_ERROR_POLICY_LOG, str) == 0) {
+        return ERROR_POLICY_LOG;
+    } else if (strcmp(PROTOCOL_ERROR_POLICY_EXIT, str) == 0) {
+        return ERROR_POLICY_EXIT;
+    } else {
+        ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+                    errmsg("invalid error_policy: %s", str)));
+        return ERROR_POLICY_UNDEFINED;
+    }
+}
+
+const char* error_policy_name(error_policy_t policy) {
+    switch (policy) {
+        case ERROR_POLICY_LOG: return PROTOCOL_ERROR_POLICY_LOG;
+        case ERROR_POLICY_EXIT: return PROTOCOL_ERROR_POLICY_EXIT;
+        case ERROR_POLICY_UNDEFINED: return "undefined (probably a bug)";
+        default: return "unknown (probably a bug)";
+    }
+}

--- a/ext/error_policy.c
+++ b/ext/error_policy.c
@@ -24,3 +24,17 @@ const char* error_policy_name(error_policy_t policy) {
         default: return "unknown (probably a bug)";
     }
 }
+
+
+void error_policy_handle(error_policy_t policy, const char *message, const char *error) {
+    switch (policy) {
+    case ERROR_POLICY_LOG:
+        elog(WARNING, "%s: %s", message, error);
+        break;
+    case ERROR_POLICY_EXIT:
+        elog(ERROR, "%s: %s", message, error);
+    default:
+        elog(WARNING, "%s: %s", message, error);
+        elog(ERROR, "error_policy_handle: unknown error policy!");
+    }
+}

--- a/ext/error_policy.h
+++ b/ext/error_policy.h
@@ -1,0 +1,15 @@
+#ifndef ERROR_POLICY_H
+#define ERROR_POLICY_H
+
+typedef enum {
+    ERROR_POLICY_UNDEFINED = 0,
+    ERROR_POLICY_LOG,
+    ERROR_POLICY_EXIT
+} error_policy_t;
+
+static const error_policy_t DEFAULT_ERROR_POLICY = ERROR_POLICY_EXIT;
+
+error_policy_t parse_error_policy(const char *str);
+const char* error_policy_name(error_policy_t policy);
+
+#endif /* ERROR_POLICY_H */

--- a/ext/error_policy.h
+++ b/ext/error_policy.h
@@ -12,4 +12,16 @@ static const error_policy_t DEFAULT_ERROR_POLICY = ERROR_POLICY_EXIT;
 error_policy_t parse_error_policy(const char *str);
 const char* error_policy_name(error_policy_t policy);
 
+/* Handles an error according to the supplied policy.
+ *
+ * `message` should describe the context in which the error occurred, e.g. what
+ * the calling function was attempting to do.
+ *
+ * `error` should describe the error that occurred.
+ *
+ * This will call `ereport` with an appropriate severity depending on the
+ * policy, so this may cause an early exit from the calling function.
+ */
+void error_policy_handle(error_policy_t policy, const char *message, const char *error);
+
 #endif /* ERROR_POLICY_H */

--- a/ext/logdecoder.c
+++ b/ext/logdecoder.c
@@ -195,9 +195,9 @@ static void output_avro_change(LogicalDecodingContext *ctx, ReorderBufferTXN *tx
 }
 
 error_policy_t parse_error_policy(const char *str) {
-    if (strcmp("log", str) == 0) {
+    if (strcmp(PROTOCOL_ERROR_POLICY_LOG, str) == 0) {
         return ERROR_POLICY_LOG;
-    } else if (strcmp("exit", str) == 0) {
+    } else if (strcmp(PROTOCOL_ERROR_POLICY_EXIT, str) == 0) {
         return ERROR_POLICY_EXIT;
     } else {
         ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
@@ -208,8 +208,8 @@ error_policy_t parse_error_policy(const char *str) {
 
 const char* error_policy_name(error_policy_t policy) {
     switch (policy) {
-        case ERROR_POLICY_LOG: return "log";
-        case ERROR_POLICY_EXIT: return "exit";
+        case ERROR_POLICY_LOG: return PROTOCOL_ERROR_POLICY_LOG;
+        case ERROR_POLICY_EXIT: return PROTOCOL_ERROR_POLICY_EXIT;
         case ERROR_POLICY_UNDEFINED: return "undefined (probably a bug)";
         default: return "unknown (probably a bug)";
     }

--- a/ext/protocol.h
+++ b/ext/protocol.h
@@ -24,6 +24,26 @@
 #define PROTOCOL_MSG_DELETE         5
 
 
+/* Error policies, determining what the snapshot function and output plugin
+ * should do if they encounter an error encoding a row.
+ *
+ * These should match the values of the bottledwater_error_policy_valid
+ * constraint in bottledwater--0.1.sql.
+ */
+/* The default policy is "exit": an error will terminate the snapshot or
+ * replication stream.  This policy should be used if avoiding data loss is the
+ * top priority, since after manually resolving the error Bottled Water can be
+ * restarted to retry the affected rows.
+ */
+#define PROTOCOL_ERROR_POLICY_EXIT "exit"
+/* Under the "log" policy, an error will cause Bottled Water to skip over the
+ * affected rows and continue, logging the error that occurred.  This means the
+ * snapshot or replication stream may omit some updates that were successfully
+ * committed to Postgres, if there was a problem encoding those updates.
+ */
+#define PROTOCOL_ERROR_POLICY_LOG "log"
+
+
 avro_schema_t schema_for_frame(void);
 
 #endif /* PROTOCOL_H */

--- a/ext/snapshot.c
+++ b/ext/snapshot.c
@@ -1,6 +1,7 @@
 #include "io_util.h"
 #include "oid2avro.h"
 #include "protocol_server.h"
+#include "error_policy.h"
 
 #include <string.h>
 #include "postgres.h"
@@ -30,6 +31,7 @@ typedef struct {
 typedef struct {
     MemoryContext memcontext;
     export_table *tables;
+    error_policy_t error_policy;
     int num_tables, current_table;
     avro_schema_t frame_schema;
     avro_value_iface_t *frame_iface;
@@ -103,6 +105,8 @@ Datum bottledwater_export(PG_FUNCTION_ARGS) {
     MemoryContext oldcontext;
     export_state *state;
     int ret;
+    text *table_pattern;
+    bool allow_unkeyed;
     bytea *result;
 
     oldcontext = CurrentMemoryContext;
@@ -135,7 +139,11 @@ Datum bottledwater_export(PG_FUNCTION_ARGS) {
         state->schema_cache = schema_cache_new(funcctx->multi_call_memory_ctx);
         funcctx->user_fctx = state;
 
-        get_table_list(state, PG_GETARG_TEXT_P(0), PG_GETARG_BOOL(1));
+        table_pattern = PG_GETARG_TEXT_P(0);
+        allow_unkeyed = PG_GETARG_BOOL(1);
+        state->error_policy = parse_error_policy(TextDatumGetCString(PG_GETARG_TEXT_P(2)));
+
+        get_table_list(state, table_pattern, allow_unkeyed);
         if (state->num_tables > 0) open_next_table(state);
     }
 
@@ -332,7 +340,15 @@ bytea *format_snapshot_row(export_state *state) {
             SPI_tuptable->tupdesc, SPI_tuptable->vals[0])) {
         elog(INFO, "Failed tuptable: %s", schema_debug_info(table->rel, SPI_tuptable->tupdesc));
         elog(INFO, "Failed relation: %s", schema_debug_info(table->rel, RelationGetDescr(table->rel)));
-        elog(ERROR, "bottledwater_export: Avro conversion failed: %s", avro_strerror());
+        switch (state->error_policy) {
+        case ERROR_POLICY_LOG:
+            elog(WARNING, "bottledwater_export: Avro conversion failed: %s", avro_strerror());
+            break;
+        case ERROR_POLICY_EXIT:
+            elog(ERROR, "bottledwater_export: Avro conversion failed: %s", avro_strerror());
+        default:
+            elog(ERROR, "AHHH WTF");
+        }
     }
     if (try_writing(&output, &write_avro_binary, &state->frame_value)) {
         elog(ERROR, "bottledwater_export: writing Avro binary failed: %s", avro_strerror());

--- a/spec/bin/generate_type_specs.rb
+++ b/spec/bin/generate_type_specs.rb
@@ -97,6 +97,7 @@ BOUNDED_LENGTH_TYPES = Set[*%w(
 INTERNAL_TYPES = Set[*%w(
   abstime
   aclitem
+  bottledwater_error_policy
   "char"
   cid
   ghstore

--- a/spec/functional/error_handling_spec.rb
+++ b/spec/functional/error_handling_spec.rb
@@ -1,10 +1,13 @@
 require 'spec_helper'
+require 'format_contexts'
 require 'test_cluster'
 
-describe 'outages', functional: true do
+describe 'error handling', functional: true, format: :json do
   after(:example) do
     TEST_CLUSTER.stop(dump_logs: false)
   end
+
+  LONG_STRING = ('x' * 2_000_000).freeze
 
   let(:postgres) { TEST_CLUSTER.postgres }
 
@@ -37,6 +40,16 @@ describe 'outages', functional: true do
 
         expect(TEST_CLUSTER.bottledwater_running?).to be_falsy
       end
+    end
+
+    example 'writing a large value crashes Bottled Water' do
+      TEST_CLUSTER.start
+
+      postgres.exec('CREATE TABLE events (id SERIAL PRIMARY KEY, event TEXT)')
+      postgres.exec_params('INSERT INTO events (event) VALUES ($1)', [LONG_STRING])
+      sleep 5
+
+      expect(TEST_CLUSTER.bottledwater_running?).to be_falsy
     end
   end
 
@@ -79,6 +92,20 @@ describe 'outages', functional: true do
 
         expect(TEST_CLUSTER.bottledwater_running?).to be_truthy
       end
+    end
+
+    example 'a row with a large value gets skipped without stopping replication' do
+      TEST_CLUSTER.start
+
+      postgres.exec('CREATE TABLE events (id SERIAL PRIMARY KEY NOT NULL, event TEXT)')
+      postgres.exec_params('INSERT INTO events (event) VALUES ($1)', ['Wednesday'])
+      postgres.exec_params('INSERT INTO events (event) VALUES ($1)', [LONG_STRING])
+      postgres.exec_params('INSERT INTO events (event) VALUES ($1)', ['Friday'])
+      sleep 1
+
+      messages = kafka_take_messages('events', 2)
+      events = messages.map {|message| fetch_string(decode_value(message.value), 'event') }
+      expect(events).to eq(['Wednesday', 'Friday'])
     end
   end
 end

--- a/spec/functional/type_specs.rb
+++ b/spec/functional/type_specs.rb
@@ -40,6 +40,10 @@ shared_examples 'type specs' do
     include_examples 'roundtrip type', "boolean", true
   end
 
+  describe 'bottledwater_error_policy' do
+    example('internal type not supported') {}
+  end
+
   describe 'box' do
     include_examples 'geometric type', "box", "(3,4),(0,0)"
   end


### PR DESCRIPTION
This adds an additional `error_policy` parameter to the snapshot function `bottledwater_export` and the logical decoding output plugin (specified via `START_REPLICATION`), with similar semantics to the `--on-error` flag added to the client in PR #85.  The default policy is "exit", which preserves the existing behaviour that any error encoding a row for output to the client will terminate the snapshot or replication stream.  Under the "log" policy, instead the error will just be logged and the offending row skipped.

This also ensures that the Bottled Water client passes the policy specified by `--on-error` down to the snapshot and output plugin.  Previously this could lead to a confusing situation where you specified `--on-error=log` but some errors would still terminate (since the error policy did not apply to the extension): e.g. #36 and #113.

It also adds tests for handling of large values that exceed the extension's internal maximum buffer size, to illustrate and test for the difference between error policies.

This does not actually guarantee that *all* errors will be skipped in "log" mode - currently it skips only Avro encoding errors and errors writing the buffer.  (e.g. it will probably not currently catch the "missing chunk for toast value" error described in #113.)  This is because the extension was originally coded with the assumption that any error would exit early, and so it may not be safe to continue on after all possible errors - an unanticipated error might leave the extension in a bad state.  We should be able to add handling for additional errors on a case by case basis.