### PR TITLE
Add CONTRIBUTORS file

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,35 @@
+Bottled Water contributors
+--------------------------
+
+Listed alphabetically by Github screen name.  This is not a comprehensive list of
+contributors or their contributions; for full details, see the Github [Contributors
+page](https://github.com/confluentinc/bottledwater-pg/graphs/contributors).
+
+* [a1exsh](https://github.com/a1exsh)
+    * bug fixes
+* [badboyd](https://github.com/badboyd)
+    * fixed a memory leak
+* [bchazalet](https://github.com/bchazalet)
+    * fixed a crash under high load
+* [ept](https://github.com/ept) (sponsored by [Confluent
+  Inc](http://www.confluent.io/))
+    * initial concept and implementation
+* [fearofcode](https://github.com/fearofcode)
+    * build fixes
+* [gonzalo-bulnes](https://github.com/gonzalo-bulnes)
+    * documented required dependency versions
+* [juliaaano](https://github.com/juliaaano)
+    * build fixes
+* [mcapitanio](https://github.com/mcapitanio)
+    * include Postgres schema name in Kafka topic name
+* [samstokes](https://github.com/samstokes) (sponsored by [Heroku, a Salesforce
+  company](https://www.heroku.com/))
+    * JSON output format
+    * Topic name prefix
+    * `--on-error=log`
+    * Support skipping snapshot on startup
+    * Automated test suite and Travis CI setup
+* [tkaemming](https://github.com/tkaemming)
+    * Docker Compose setup
+* [tkothe](https://github.com/tkothe)
+    * documentation fixes

--- a/README.md
+++ b/README.md
@@ -498,10 +498,13 @@ License
 Copyright 2015 Confluent, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
-software except in compliance with the License in the enclosed file called `LICENSE`.
+software except in compliance with the License in the enclosed file called
+[`LICENSE`](LICENSE).
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+
+See [`CONTRIBUTORS.md`](CONTRIBUTORS.md) for a list of contributors.


### PR DESCRIPTION
This adds a CONTRIBUTORS file to give credit to everyone who's contributed to Bottled Water.  This is my quick attempt at a starting point, and is not exhaustive (we have the commit history for that!) - many apologies if I've forgotten anyone or unintentionally downplayed your contribution!  If you'd like your contribution described in more detail, or want to add attribution for your employer, please submit a PR and I'll be happy to merge it.