### PR TITLE
Updated PSQL entrypoint in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,7 +87,7 @@ psql:
   image: postgres:9.5
   links:
     - postgres
-  entrypoint: ['psql', '-h', 'postgres', '-U', 'postgres']
+  entrypoint: ['psql', '-hpostgres', '-Upostgres']
 kafka-console-consumer:
   image: confluent/tools:0.9.0.0-cp1
   links:


### PR DESCRIPTION
When running ```make docker-compose``` after a fresh clone, it's complaining about duplicate entries in docker-compose.yml.

This solved the issue.

What do you think ?